### PR TITLE
feat: implement location and department management endpoints

### DIFF
--- a/src/main/java/com/shiftsync/shiftsync/common/util/AuthenticationHelper.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/util/AuthenticationHelper.java
@@ -1,0 +1,38 @@
+package com.shiftsync.shiftsync.common.util;
+
+import com.shiftsync.shiftsync.common.exception.UnauthorizedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthenticationHelper {
+
+    public Long getCurrentUserId(Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new UnauthorizedException("Authentication required");
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof Long value) {
+            return value;
+        }
+        if (principal instanceof String value) {
+            try {
+                return Long.parseLong(value);
+            } catch (NumberFormatException ex) {
+                throw new UnauthorizedException("Invalid authentication principal");
+            }
+        }
+        if (principal instanceof UserDetails userDetails) {
+            try {
+                return Long.parseLong(userDetails.getUsername());
+            } catch (NumberFormatException ex) {
+                throw new UnauthorizedException("Invalid authentication principal");
+            }
+        }
+
+        throw new UnauthorizedException("Invalid authentication principal");
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/department/controller/DepartmentController.java
+++ b/src/main/java/com/shiftsync/shiftsync/department/controller/DepartmentController.java
@@ -1,0 +1,69 @@
+package com.shiftsync.shiftsync.department.controller;
+
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.department.dto.CreateDepartmentRequest;
+import com.shiftsync.shiftsync.department.dto.DepartmentResponse;
+import com.shiftsync.shiftsync.department.service.DepartmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/locations/{locationId}/departments")
+@RequiredArgsConstructor
+@Tag(name = "Departments", description = "Department management endpoints")
+public class DepartmentController {
+
+    private final DepartmentService departmentService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(summary = "Create department", description = "Creates a department inside a location.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Department created", content = @Content(schema = @Schema(implementation = DepartmentResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Location not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Duplicate department name", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<DepartmentResponse> createDepartment(
+            @Parameter(description = "Location ID", required = true) @PathVariable Long locationId,
+            @Valid @RequestBody CreateDepartmentRequest request
+    ) {
+        DepartmentResponse response = departmentService.createDepartment(locationId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('HR_ADMIN','MANAGER')")
+    @Operation(summary = "Get departments by location", description = "Lists all departments for a given location.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Departments fetched", content = @Content(array = @ArraySchema(schema = @Schema(implementation = DepartmentResponse.class)))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Location not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<DepartmentResponse>> getDepartmentsByLocation(
+            @Parameter(description = "Location ID", required = true) @PathVariable Long locationId
+    ) {
+        return ResponseEntity.ok(departmentService.getDepartmentsByLocation(locationId));
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/department/dto/CreateDepartmentRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/department/dto/CreateDepartmentRequest.java
@@ -1,0 +1,10 @@
+package com.shiftsync.shiftsync.department.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateDepartmentRequest(
+        @NotBlank(message = "Department name is required")
+        String name
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/department/dto/DepartmentResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/department/dto/DepartmentResponse.java
@@ -1,0 +1,9 @@
+package com.shiftsync.shiftsync.department.dto;
+
+public record DepartmentResponse(
+        Long id,
+        Long locationId,
+        String name
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/department/entity/Department.java
+++ b/src/main/java/com/shiftsync/shiftsync/department/entity/Department.java
@@ -1,16 +1,24 @@
 package com.shiftsync.shiftsync.department.entity;
 
+import com.shiftsync.shiftsync.location.entity.Location;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "departments")
@@ -27,5 +35,26 @@ public class Department {
 
     @Column(nullable = false)
     private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", nullable = false)
+    private Location location;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/department/mapper/DepartmentMapper.java
+++ b/src/main/java/com/shiftsync/shiftsync/department/mapper/DepartmentMapper.java
@@ -1,0 +1,18 @@
+package com.shiftsync.shiftsync.department.mapper;
+
+import com.shiftsync.shiftsync.department.dto.DepartmentResponse;
+import com.shiftsync.shiftsync.department.entity.Department;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DepartmentMapper {
+
+    public DepartmentResponse toResponse(Department department) {
+        return new DepartmentResponse(
+                department.getId(),
+                department.getLocation().getId(),
+                department.getName()
+        );
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/department/repository/DepartmentRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/department/repository/DepartmentRepository.java
@@ -4,7 +4,29 @@ import com.shiftsync.shiftsync.department.entity.Department;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+/**
+ * The interface Department repository.
+ */
 @Repository
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
+
+	/**
+	 * Exists by location id and name ignore case boolean.
+	 *
+	 * @param locationId the location id
+	 * @param name       the name
+	 * @return the boolean
+	 */
+	boolean existsByLocationIdAndNameIgnoreCase(Long locationId, String name);
+
+	/**
+	 * Find all by location id order by name asc list.
+	 *
+	 * @param locationId the location id
+	 * @return the list
+	 */
+	List<Department> findAllByLocationIdOrderByNameAsc(Long locationId);
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/department/service/DepartmentService.java
+++ b/src/main/java/com/shiftsync/shiftsync/department/service/DepartmentService.java
@@ -1,0 +1,30 @@
+package com.shiftsync.shiftsync.department.service;
+
+import com.shiftsync.shiftsync.department.dto.CreateDepartmentRequest;
+import com.shiftsync.shiftsync.department.dto.DepartmentResponse;
+
+import java.util.List;
+
+/**
+ * The interface Department service.
+ */
+public interface DepartmentService {
+
+    /**
+     * Create department department response.
+     *
+     * @param locationId the location id
+     * @param request    the request
+     * @return the department response
+     */
+    DepartmentResponse createDepartment(Long locationId, CreateDepartmentRequest request);
+
+    /**
+     * Gets departments by location.
+     *
+     * @param locationId the location id
+     * @return the departments by location
+     */
+    List<DepartmentResponse> getDepartmentsByLocation(Long locationId);
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/department/service/impl/DepartmentServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/department/service/impl/DepartmentServiceImpl.java
@@ -1,0 +1,60 @@
+package com.shiftsync.shiftsync.department.service.impl;
+
+import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.department.dto.CreateDepartmentRequest;
+import com.shiftsync.shiftsync.department.dto.DepartmentResponse;
+import com.shiftsync.shiftsync.department.entity.Department;
+import com.shiftsync.shiftsync.department.mapper.DepartmentMapper;
+import com.shiftsync.shiftsync.department.repository.DepartmentRepository;
+import com.shiftsync.shiftsync.department.service.DepartmentService;
+import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.location.repository.LocationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DepartmentServiceImpl implements DepartmentService {
+
+    private final DepartmentRepository departmentRepository;
+    private final LocationRepository locationRepository;
+    private final DepartmentMapper departmentMapper;
+
+    @Override
+    @Transactional
+    public DepartmentResponse createDepartment(Long locationId, CreateDepartmentRequest request) {
+        Location location = locationRepository.findById(locationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Location not found"));
+
+        String normalizedName = request.name().trim();
+        if (departmentRepository.existsByLocationIdAndNameIgnoreCase(locationId, normalizedName)) {
+            throw new DuplicateResourceException("Department name already exists for this location");
+        }
+
+        Department department = Department.builder()
+                .location(location)
+                .name(normalizedName)
+                .build();
+
+        Department saved = departmentRepository.save(department);
+        return departmentMapper.toResponse(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<DepartmentResponse> getDepartmentsByLocation(Long locationId) {
+        if (!locationRepository.existsById(locationId)) {
+            throw new ResourceNotFoundException("Location not found");
+        }
+
+        return departmentRepository.findAllByLocationIdOrderByNameAsc(locationId)
+                .stream()
+                .map(departmentMapper::toResponse)
+                .toList();
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/employee/controller/EmployeeController.java
+++ b/src/main/java/com/shiftsync/shiftsync/employee/controller/EmployeeController.java
@@ -1,8 +1,8 @@
 package com.shiftsync.shiftsync.employee.controller;
 
 import com.shiftsync.shiftsync.common.enums.EmploymentType;
-import com.shiftsync.shiftsync.common.exception.UnauthorizedException;
 import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.employee.dto.CreateEmployeeRequest;
 import com.shiftsync.shiftsync.employee.dto.EmployeePageResponse;
 import com.shiftsync.shiftsync.employee.dto.EmployeeResponse;
@@ -22,7 +22,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +40,7 @@ import java.util.Collection;
 public class EmployeeController {
 
     private final EmployeeService employeeService;
+    private final AuthenticationHelper authenticationHelper;
 
     @PostMapping
     @PreAuthorize("hasRole('HR_ADMIN')")
@@ -108,7 +108,7 @@ public class EmployeeController {
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "lastName") String sortBy
     ) {
-        Long actorUserId = getCurrentUserId(authentication);
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
         boolean isManager = isManager(authentication.getAuthorities());
 
         GetEmployeesRequest request = new GetEmployeesRequest(
@@ -135,7 +135,7 @@ public class EmployeeController {
             @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<EmployeeResponse> getMyProfile(Authentication authentication) {
-        Long actorUserId = getCurrentUserId(authentication);
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
         return ResponseEntity.ok(employeeService.getMyProfile(actorUserId));
     }
 
@@ -150,7 +150,7 @@ public class EmployeeController {
             Authentication authentication,
             @RequestBody UpdateMyProfileRequest request
     ) {
-        Long actorUserId = getCurrentUserId(authentication);
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
         return ResponseEntity.ok(employeeService.updateMyProfile(actorUserId, request));
     }
 
@@ -166,7 +166,7 @@ public class EmployeeController {
             Authentication authentication,
             @PathVariable Long id
     ) {
-        Long actorUserId = getCurrentUserId(authentication);
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
         boolean isManager = isManager(authentication.getAuthorities());
         return ResponseEntity.ok(employeeService.getEmployeeById(actorUserId, isManager, id));
     }
@@ -183,32 +183,6 @@ public class EmployeeController {
         return ResponseEntity.ok(employeeService.deactivateEmployee(id));
     }
 
-    private Long getCurrentUserId(Authentication authentication) {
-        if (authentication == null || authentication.getPrincipal() == null) {
-            throw new UnauthorizedException("Authentication required");
-        }
-
-        Object principal = authentication.getPrincipal();
-        if (principal instanceof Long value) {
-            return value;
-        }
-        if (principal instanceof String value) {
-            try {
-                return Long.parseLong(value);
-            } catch (NumberFormatException ex) {
-                throw new UnauthorizedException("Invalid authentication principal");
-            }
-        }
-        if (principal instanceof UserDetails userDetails) {
-            try {
-                return Long.parseLong(userDetails.getUsername());
-            } catch (NumberFormatException ex) {
-                throw new UnauthorizedException("Invalid authentication principal");
-            }
-        }
-
-        throw new UnauthorizedException("Invalid authentication principal");
-    }
 
     private boolean isManager(Collection<? extends GrantedAuthority> authorities) {
         return authorities.stream().anyMatch(a -> "ROLE_MANAGER".equals(a.getAuthority()));

--- a/src/main/java/com/shiftsync/shiftsync/location/controller/LocationController.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/controller/LocationController.java
@@ -1,0 +1,79 @@
+package com.shiftsync.shiftsync.location.controller;
+
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.location.dto.CreateLocationRequest;
+import com.shiftsync.shiftsync.location.dto.LocationResponse;
+import com.shiftsync.shiftsync.location.dto.UpdateLocationRequest;
+import com.shiftsync.shiftsync.location.service.LocationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/locations")
+@RequiredArgsConstructor
+@Tag(name = "Locations", description = "Location management endpoints")
+public class LocationController {
+
+    private final LocationService locationService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(summary = "Create location", description = "Creates a new location for HR admins.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Location created", content = @Content(schema = @Schema(implementation = LocationResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Duplicate location name", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LocationResponse> createLocation(@Valid @RequestBody CreateLocationRequest request) {
+        LocationResponse response = locationService.createLocation(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "Get active locations", description = "Returns all active locations.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Locations fetched", content = @Content(array = @ArraySchema(schema = @Schema(implementation = LocationResponse.class)))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<LocationResponse>> getActiveLocations() {
+        return ResponseEntity.ok(locationService.getActiveLocations());
+    }
+
+    @PatchMapping("/{id}")
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(summary = "Update location", description = "Updates location details for HR admins.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Location updated", content = @Content(schema = @Schema(implementation = LocationResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Location not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Duplicate location name", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LocationResponse> updateLocation(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateLocationRequest request
+    ) {
+        return ResponseEntity.ok(locationService.updateLocation(id, request));
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/location/controller/ManagerLocationController.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/controller/ManagerLocationController.java
@@ -1,7 +1,7 @@
 package com.shiftsync.shiftsync.location.controller;
 
-import com.shiftsync.shiftsync.common.exception.UnauthorizedException;
 import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.location.dto.LocationResponse;
 import com.shiftsync.shiftsync.location.service.LocationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +28,7 @@ import java.util.List;
 public class ManagerLocationController {
 
     private final LocationService locationService;
+    private final AuthenticationHelper authenticationHelper;
 
     @GetMapping("/locations")
     @PreAuthorize("hasRole('MANAGER')")
@@ -42,35 +42,8 @@ public class ManagerLocationController {
             @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<List<LocationResponse>> getMyAssignedLocations(Authentication authentication) {
-        Long actorUserId = getCurrentUserId(authentication);
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
         return ResponseEntity.ok(locationService.getAssignedLocationsForManager(actorUserId));
-    }
-
-    private Long getCurrentUserId(Authentication authentication) {
-        if (authentication == null || authentication.getPrincipal() == null) {
-            throw new UnauthorizedException("Authentication required");
-        }
-
-        Object principal = authentication.getPrincipal();
-        if (principal instanceof Long value) {
-            return value;
-        }
-        if (principal instanceof String value) {
-            try {
-                return Long.parseLong(value);
-            } catch (NumberFormatException ex) {
-                throw new UnauthorizedException("Invalid authentication principal");
-            }
-        }
-        if (principal instanceof UserDetails userDetails) {
-            try {
-                return Long.parseLong(userDetails.getUsername());
-            } catch (NumberFormatException ex) {
-                throw new UnauthorizedException("Invalid authentication principal");
-            }
-        }
-
-        throw new UnauthorizedException("Invalid authentication principal");
     }
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/location/controller/ManagerLocationController.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/controller/ManagerLocationController.java
@@ -1,0 +1,76 @@
+package com.shiftsync.shiftsync.location.controller;
+
+import com.shiftsync.shiftsync.common.exception.UnauthorizedException;
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.location.dto.LocationResponse;
+import com.shiftsync.shiftsync.location.service.LocationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/managers/me")
+@RequiredArgsConstructor
+@Tag(name = "Manager Locations", description = "Manager location assignment endpoints")
+public class ManagerLocationController {
+
+    private final LocationService locationService;
+
+    @GetMapping("/locations")
+    @PreAuthorize("hasRole('MANAGER')")
+    @Operation(
+            summary = "Get assigned locations",
+            description = "Returns locations assigned to the authenticated manager."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Locations fetched", content = @Content(array = @ArraySchema(schema = @Schema(implementation = LocationResponse.class)))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<LocationResponse>> getMyAssignedLocations(Authentication authentication) {
+        Long actorUserId = getCurrentUserId(authentication);
+        return ResponseEntity.ok(locationService.getAssignedLocationsForManager(actorUserId));
+    }
+
+    private Long getCurrentUserId(Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new UnauthorizedException("Authentication required");
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof Long value) {
+            return value;
+        }
+        if (principal instanceof String value) {
+            try {
+                return Long.parseLong(value);
+            } catch (NumberFormatException ex) {
+                throw new UnauthorizedException("Invalid authentication principal");
+            }
+        }
+        if (principal instanceof UserDetails userDetails) {
+            try {
+                return Long.parseLong(userDetails.getUsername());
+            } catch (NumberFormatException ex) {
+                throw new UnauthorizedException("Invalid authentication principal");
+            }
+        }
+
+        throw new UnauthorizedException("Invalid authentication principal");
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/location/dto/CreateLocationRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/dto/CreateLocationRequest.java
@@ -1,0 +1,19 @@
+package com.shiftsync.shiftsync.location.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateLocationRequest(
+        @NotBlank(message = "Location name is required")
+        String name,
+
+        @NotBlank(message = "Location address is required")
+        String address,
+
+        @NotNull(message = "Max headcount per shift is required")
+        @Min(value = 1, message = "Max headcount per shift must be at least 1")
+        Integer maxHeadcountPerShift
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/location/dto/LocationResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/dto/LocationResponse.java
@@ -1,0 +1,11 @@
+package com.shiftsync.shiftsync.location.dto;
+
+public record LocationResponse(
+        Long id,
+        String name,
+        String address,
+        Integer maxHeadcountPerShift,
+        Boolean active
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/location/dto/UpdateLocationRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/dto/UpdateLocationRequest.java
@@ -1,0 +1,13 @@
+package com.shiftsync.shiftsync.location.dto;
+
+import jakarta.validation.constraints.Min;
+
+public record UpdateLocationRequest(
+        String name,
+        String address,
+        @Min(value = 1, message = "Max headcount per shift must be at least 1")
+        Integer maxHeadcountPerShift,
+        Boolean active
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/location/entity/Location.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/entity/Location.java
@@ -5,12 +5,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "locations")
@@ -27,5 +31,34 @@ public class Location {
 
     @Column(nullable = false)
     private String name;
+
+    @Column(nullable = false)
+    private String address;
+
+    @Column(name = "max_headcount_per_shift", nullable = false)
+    private Integer maxHeadcountPerShift;
+
+    @Column(nullable = false)
+    private Boolean active;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (active == null) {
+            active = true;
+        }
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/location/mapper/LocationMapper.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/mapper/LocationMapper.java
@@ -1,0 +1,20 @@
+package com.shiftsync.shiftsync.location.mapper;
+
+import com.shiftsync.shiftsync.location.dto.LocationResponse;
+import com.shiftsync.shiftsync.location.entity.Location;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocationMapper {
+
+    public LocationResponse toResponse(Location location) {
+        return new LocationResponse(
+                location.getId(),
+                location.getName(),
+                location.getAddress(),
+                location.getMaxHeadcountPerShift(),
+                location.getActive()
+        );
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/location/repository/LocationRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/repository/LocationRepository.java
@@ -4,10 +4,36 @@ import com.shiftsync.shiftsync.location.entity.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 /**
  * The interface Location repository.
  */
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
+
+	/**
+	 * Exists by name ignore case boolean.
+	 *
+	 * @param name the name
+	 * @return the boolean
+	 */
+	boolean existsByNameIgnoreCase(String name);
+
+	/**
+	 * Exists by name ignore case and id not boolean.
+	 *
+	 * @param name the name
+	 * @param id   the id
+	 * @return the boolean
+	 */
+	boolean existsByNameIgnoreCaseAndIdNot(String name, Long id);
+
+	/**
+	 * Find all by active true list.
+	 *
+	 * @return the list
+	 */
+	List<Location> findAllByActiveTrue();
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/location/service/LocationService.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/service/LocationService.java
@@ -27,6 +27,14 @@ public interface LocationService {
     List<LocationResponse> getActiveLocations();
 
     /**
+     * Gets assigned locations for manager.
+     *
+     * @param actorUserId the actor user id
+     * @return the assigned locations for manager
+     */
+    List<LocationResponse> getAssignedLocationsForManager(Long actorUserId);
+
+    /**
      * Update location location response.
      *
      * @param locationId the location id

--- a/src/main/java/com/shiftsync/shiftsync/location/service/LocationService.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/service/LocationService.java
@@ -1,0 +1,38 @@
+package com.shiftsync.shiftsync.location.service;
+
+import com.shiftsync.shiftsync.location.dto.CreateLocationRequest;
+import com.shiftsync.shiftsync.location.dto.LocationResponse;
+import com.shiftsync.shiftsync.location.dto.UpdateLocationRequest;
+
+import java.util.List;
+
+/**
+ * The interface Location service.
+ */
+public interface LocationService {
+
+    /**
+     * Create location location response.
+     *
+     * @param request the request
+     * @return the location response
+     */
+    LocationResponse createLocation(CreateLocationRequest request);
+
+    /**
+     * Gets active locations.
+     *
+     * @return the active locations
+     */
+    List<LocationResponse> getActiveLocations();
+
+    /**
+     * Update location location response.
+     *
+     * @param locationId the location id
+     * @param request    the request
+     * @return the location response
+     */
+    LocationResponse updateLocation(Long locationId, UpdateLocationRequest request);
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/location/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/service/impl/LocationServiceImpl.java
@@ -1,0 +1,84 @@
+package com.shiftsync.shiftsync.location.service.impl;
+
+import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.location.dto.CreateLocationRequest;
+import com.shiftsync.shiftsync.location.dto.LocationResponse;
+import com.shiftsync.shiftsync.location.dto.UpdateLocationRequest;
+import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.location.mapper.LocationMapper;
+import com.shiftsync.shiftsync.location.repository.LocationRepository;
+import com.shiftsync.shiftsync.location.service.LocationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LocationServiceImpl implements LocationService {
+
+    private final LocationRepository locationRepository;
+    private final LocationMapper locationMapper;
+
+    @Override
+    @Transactional
+    public LocationResponse createLocation(CreateLocationRequest request) {
+        if (locationRepository.existsByNameIgnoreCase(request.name())) {
+            throw new DuplicateResourceException("Location name already exists");
+        }
+
+        Location location = Location.builder()
+                .name(request.name().trim())
+                .address(request.address().trim())
+                .maxHeadcountPerShift(request.maxHeadcountPerShift())
+                .active(true)
+                .build();
+
+        Location saved = locationRepository.save(location);
+        return locationMapper.toResponse(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LocationResponse> getActiveLocations() {
+        return locationRepository.findAllByActiveTrue()
+                .stream()
+                .map(locationMapper::toResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public LocationResponse updateLocation(Long locationId, UpdateLocationRequest request) {
+        Location location = locationRepository.findById(locationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Location not found"));
+
+        if (request.name() != null) {
+            String normalizedName = request.name().trim();
+            if (locationRepository.existsByNameIgnoreCaseAndIdNot(normalizedName, locationId)) {
+                throw new DuplicateResourceException("Location name already exists");
+            }
+            location.setName(normalizedName);
+        }
+
+        if (request.address() != null) {
+            String normalizedAddress = request.address().trim();
+            location.setAddress(normalizedAddress);
+        }
+
+        if (request.maxHeadcountPerShift() != null) {
+            location.setMaxHeadcountPerShift(request.maxHeadcountPerShift());
+        }
+
+        if (request.active() != null) {
+            location.setActive(request.active());
+        }
+
+        Location saved = locationRepository.save(location);
+        return locationMapper.toResponse(saved);
+    }
+}
+
+

--- a/src/main/java/com/shiftsync/shiftsync/location/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/service/impl/LocationServiceImpl.java
@@ -2,11 +2,14 @@ package com.shiftsync.shiftsync.location.service.impl;
 
 import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.location.dto.CreateLocationRequest;
 import com.shiftsync.shiftsync.location.dto.LocationResponse;
 import com.shiftsync.shiftsync.location.dto.UpdateLocationRequest;
 import com.shiftsync.shiftsync.location.entity.Location;
 import com.shiftsync.shiftsync.location.mapper.LocationMapper;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
 import com.shiftsync.shiftsync.location.repository.LocationRepository;
 import com.shiftsync.shiftsync.location.service.LocationService;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +23,8 @@ import java.util.List;
 public class LocationServiceImpl implements LocationService {
 
     private final LocationRepository locationRepository;
+    private final EmployeeRepository employeeRepository;
+    private final ManagerLocationRepository managerLocationRepository;
     private final LocationMapper locationMapper;
 
     @Override
@@ -44,6 +49,23 @@ public class LocationServiceImpl implements LocationService {
     @Transactional(readOnly = true)
     public List<LocationResponse> getActiveLocations() {
         return locationRepository.findAllByActiveTrue()
+                .stream()
+                .map(locationMapper::toResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LocationResponse> getAssignedLocationsForManager(Long actorUserId) {
+        Employee manager = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
+
+        List<Long> locationIds = managerLocationRepository.findLocationIdsByManagerEmployeeId(manager.getId());
+        if (locationIds.isEmpty()) {
+            return List.of();
+        }
+
+        return locationRepository.findAllById(locationIds)
                 .stream()
                 .map(locationMapper::toResponse)
                 .toList();

--- a/src/test/java/com/shiftsync/shiftsync/department/controller/DepartmentControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/department/controller/DepartmentControllerWebMvcTest.java
@@ -105,6 +105,20 @@ class DepartmentControllerWebMvcTest {
     }
 
     @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void createDepartment_BlankName_ReturnsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/v1/locations/1/departments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": ""
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.name").value("Department name is required"));
+    }
+
+    @Test
     @WithMockUser(roles = "MANAGER")
     void getDepartmentsByLocation_Manager_ReturnsOk() throws Exception {
         when(departmentService.getDepartmentsByLocation(1L))

--- a/src/test/java/com/shiftsync/shiftsync/department/controller/DepartmentControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/department/controller/DepartmentControllerWebMvcTest.java
@@ -1,0 +1,125 @@
+package com.shiftsync.shiftsync.department.controller;
+
+import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import com.shiftsync.shiftsync.department.dto.DepartmentResponse;
+import com.shiftsync.shiftsync.department.service.DepartmentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DepartmentController.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class DepartmentControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DepartmentService departmentService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void createDepartment_Success_ReturnsCreated() throws Exception {
+        when(departmentService.createDepartment(anyLong(), any()))
+                .thenReturn(new DepartmentResponse(10L, 1L, "Kitchen"));
+
+        mockMvc.perform(post("/api/v1/locations/1/departments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "Kitchen"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(10))
+                .andExpect(jsonPath("$.name").value("Kitchen"));
+    }
+
+    @Test
+    void createDepartment_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/v1/locations/1/departments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "Kitchen"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "MANAGER")
+    void createDepartment_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(post("/api/v1/locations/1/departments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "Kitchen"
+                                }
+                                """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void createDepartment_Duplicate_ReturnsConflict() throws Exception {
+        when(departmentService.createDepartment(anyLong(), any()))
+                .thenThrow(new DuplicateResourceException("Department name already exists for this location"));
+
+        mockMvc.perform(post("/api/v1/locations/1/departments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "name": "Kitchen"
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Department name already exists for this location"));
+    }
+
+    @Test
+    @WithMockUser(roles = "MANAGER")
+    void getDepartmentsByLocation_Manager_ReturnsOk() throws Exception {
+        when(departmentService.getDepartmentsByLocation(1L))
+                .thenReturn(List.of(new DepartmentResponse(10L, 1L, "Kitchen")));
+
+        mockMvc.perform(get("/api/v1/locations/1/departments"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Kitchen"));
+    }
+
+    @Test
+    @WithMockUser(roles = "EMPLOYEE")
+    void getDepartmentsByLocation_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/locations/1/departments"))
+                .andExpect(status().isForbidden());
+    }
+}
+

--- a/src/test/java/com/shiftsync/shiftsync/department/service/DepartmentServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/department/service/DepartmentServiceImplTest.java
@@ -1,0 +1,124 @@
+package com.shiftsync.shiftsync.department.service;
+
+import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.department.dto.CreateDepartmentRequest;
+import com.shiftsync.shiftsync.department.dto.DepartmentResponse;
+import com.shiftsync.shiftsync.department.entity.Department;
+import com.shiftsync.shiftsync.department.mapper.DepartmentMapper;
+import com.shiftsync.shiftsync.department.repository.DepartmentRepository;
+import com.shiftsync.shiftsync.department.service.impl.DepartmentServiceImpl;
+import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.location.repository.LocationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DepartmentServiceImplTest {
+
+    @Mock
+    private DepartmentRepository departmentRepository;
+
+    @Mock
+    private LocationRepository locationRepository;
+
+    @Mock
+    private DepartmentMapper departmentMapper;
+
+    @InjectMocks
+    private DepartmentServiceImpl departmentService;
+
+    private Location location;
+    private Department department;
+    private DepartmentResponse response;
+
+    @BeforeEach
+    void setUp() {
+        location = Location.builder()
+                .id(1L)
+                .name("Airport Branch")
+                .address("Airport Road")
+                .maxHeadcountPerShift(40)
+                .active(true)
+                .build();
+
+        department = Department.builder()
+                .id(10L)
+                .name("Kitchen")
+                .location(location)
+                .build();
+
+        response = new DepartmentResponse(10L, 1L, "Kitchen");
+    }
+
+    @Test
+    void createDepartment_Success() {
+        CreateDepartmentRequest request = new CreateDepartmentRequest("Kitchen");
+        when(locationRepository.findById(1L)).thenReturn(Optional.of(location));
+        when(departmentRepository.existsByLocationIdAndNameIgnoreCase(1L, "Kitchen")).thenReturn(false);
+        when(departmentRepository.save(any(Department.class))).thenReturn(department);
+        when(departmentMapper.toResponse(department)).thenReturn(response);
+
+        DepartmentResponse created = departmentService.createDepartment(1L, request);
+
+        assertThat(created.id()).isEqualTo(10L);
+        verify(departmentRepository).save(any(Department.class));
+    }
+
+    @Test
+    void createDepartment_LocationMissing_ThrowsNotFound() {
+        when(locationRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> departmentService.createDepartment(99L, new CreateDepartmentRequest("Kitchen")))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Location not found");
+
+        verify(departmentRepository, never()).save(any(Department.class));
+    }
+
+    @Test
+    void createDepartment_Duplicate_ThrowsConflict() {
+        when(locationRepository.findById(1L)).thenReturn(Optional.of(location));
+        when(departmentRepository.existsByLocationIdAndNameIgnoreCase(1L, "Kitchen")).thenReturn(true);
+
+        assertThatThrownBy(() -> departmentService.createDepartment(1L, new CreateDepartmentRequest("Kitchen")))
+                .isInstanceOf(DuplicateResourceException.class)
+                .hasMessage("Department name already exists for this location");
+    }
+
+    @Test
+    void getDepartmentsByLocation_Success() {
+        when(locationRepository.existsById(1L)).thenReturn(true);
+        when(departmentRepository.findAllByLocationIdOrderByNameAsc(1L)).thenReturn(List.of(department));
+        when(departmentMapper.toResponse(department)).thenReturn(response);
+
+        List<DepartmentResponse> departments = departmentService.getDepartmentsByLocation(1L);
+
+        assertThat(departments).hasSize(1);
+        assertThat(departments.getFirst().name()).isEqualTo("Kitchen");
+    }
+
+    @Test
+    void getDepartmentsByLocation_LocationMissing_ThrowsNotFound() {
+        when(locationRepository.existsById(88L)).thenReturn(false);
+
+        assertThatThrownBy(() -> departmentService.getDepartmentsByLocation(88L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Location not found");
+    }
+}
+

--- a/src/test/java/com/shiftsync/shiftsync/employee/controller/EmployeeControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/employee/controller/EmployeeControllerWebMvcTest.java
@@ -3,6 +3,7 @@ package com.shiftsync.shiftsync.employee.controller;
 import com.shiftsync.shiftsync.common.enums.EmploymentType;
 import com.shiftsync.shiftsync.common.enums.UserRole;
 import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
 import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
 import com.shiftsync.shiftsync.config.security.JwtService;
@@ -38,7 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(EmployeeController.class)
 @ActiveProfiles("test")
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, AuthenticationHelper.class})
 class EmployeeControllerWebMvcTest {
 
     @Autowired

--- a/src/test/java/com/shiftsync/shiftsync/location/controller/LocationControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/location/controller/LocationControllerWebMvcTest.java
@@ -100,6 +100,24 @@ class LocationControllerWebMvcTest {
     }
 
     @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void createLocation_BlankName_ReturnsBadRequest() throws Exception {
+        String body = """
+                {
+                  "name": "",
+                  "address": "Airport Road",
+                  "maxHeadcountPerShift": 40
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.name").value("Location name is required"));
+    }
+
+    @Test
     @WithMockUser
     void getActiveLocations_ReturnsOk() throws Exception {
         when(locationService.getActiveLocations())

--- a/src/test/java/com/shiftsync/shiftsync/location/controller/LocationControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/location/controller/LocationControllerWebMvcTest.java
@@ -1,0 +1,172 @@
+package com.shiftsync.shiftsync.location.controller;
+
+import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import com.shiftsync.shiftsync.location.dto.LocationResponse;
+import com.shiftsync.shiftsync.location.service.LocationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LocationController.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class LocationControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LocationService locationService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Test
+    void createLocation_WithoutToken_ReturnsUnauthorized() throws Exception {
+        String body = """
+                {
+                  "name": "Airport Branch",
+                  "address": "Airport Road",
+                  "maxHeadcountPerShift": 40
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "EMPLOYEE")
+    void createLocation_WrongRole_ReturnsForbidden() throws Exception {
+        String body = """
+                {
+                  "name": "Airport Branch",
+                  "address": "Airport Road",
+                  "maxHeadcountPerShift": 40
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void createLocation_Success_ReturnsCreated() throws Exception {
+        LocationResponse response = new LocationResponse(1L, "Airport Branch", "Airport Road", 40, true);
+        when(locationService.createLocation(any())).thenReturn(response);
+
+        String body = """
+                {
+                  "name": "Airport Branch",
+                  "address": "Airport Road",
+                  "maxHeadcountPerShift": 40
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Airport Branch"));
+    }
+
+    @Test
+    @WithMockUser
+    void getActiveLocations_ReturnsOk() throws Exception {
+        when(locationService.getActiveLocations())
+                .thenReturn(List.of(new LocationResponse(1L, "Airport Branch", "Airport Road", 40, true)));
+
+        mockMvc.perform(get("/api/v1/locations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Airport Branch"));
+    }
+
+    @Test
+    void getActiveLocations_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/locations"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void updateLocation_Success_ReturnsOk() throws Exception {
+        LocationResponse response = new LocationResponse(1L, "Airport Branch", "Airport Road", 50, true);
+        when(locationService.updateLocation(any(), any())).thenReturn(response);
+
+        String body = """
+                {
+                  "maxHeadcountPerShift": 50
+                }
+                """;
+
+        mockMvc.perform(patch("/api/v1/locations/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.maxHeadcountPerShift").value(50));
+    }
+
+    @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void updateLocation_DuplicateName_ReturnsConflict() throws Exception {
+        when(locationService.updateLocation(any(), any()))
+                .thenThrow(new DuplicateResourceException("Location name already exists"));
+
+        String body = """
+                {
+                  "name": "Airport Branch"
+                }
+                """;
+
+        mockMvc.perform(patch("/api/v1/locations/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Location name already exists"));
+    }
+
+    @Test
+    @WithMockUser(roles = "MANAGER")
+    void updateLocation_WrongRole_ReturnsForbidden() throws Exception {
+        String body = """
+                {
+                  "name": "Airport Branch"
+                }
+                """;
+
+        mockMvc.perform(patch("/api/v1/locations/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isForbidden());
+    }
+}
+

--- a/src/test/java/com/shiftsync/shiftsync/location/controller/ManagerLocationControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/location/controller/ManagerLocationControllerWebMvcTest.java
@@ -1,0 +1,79 @@
+package com.shiftsync.shiftsync.location.controller;
+
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import com.shiftsync.shiftsync.location.dto.LocationResponse;
+import com.shiftsync.shiftsync.location.service.LocationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ManagerLocationController.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class ManagerLocationControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LocationService locationService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Test
+    @WithMockUser(username = "11", roles = "MANAGER")
+    void getMyAssignedLocations_ReturnsList() throws Exception {
+        when(locationService.getAssignedLocationsForManager(11L)).thenReturn(List.of(
+                new LocationResponse(1L, "Airport Branch", "Airport Road", 40, true)
+        ));
+
+        mockMvc.perform(get("/api/v1/managers/me/locations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("Airport Branch"));
+    }
+
+    @Test
+    @WithMockUser(username = "11", roles = "MANAGER")
+    void getMyAssignedLocations_WhenNoAssignments_ReturnsEmptyList() throws Exception {
+        when(locationService.getAssignedLocationsForManager(11L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/managers/me/locations"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void getMyAssignedLocations_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/managers/me/locations"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "11", roles = "EMPLOYEE")
+    void getMyAssignedLocations_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/managers/me/locations"))
+                .andExpect(status().isForbidden());
+    }
+}
+

--- a/src/test/java/com/shiftsync/shiftsync/location/controller/ManagerLocationControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/location/controller/ManagerLocationControllerWebMvcTest.java
@@ -4,6 +4,7 @@ import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
 import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
 import com.shiftsync.shiftsync.config.security.JwtService;
 import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.location.dto.LocationResponse;
 import com.shiftsync.shiftsync.location.service.LocationService;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(ManagerLocationController.class)
 @ActiveProfiles("test")
-@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, AuthenticationHelper.class})
 class ManagerLocationControllerWebMvcTest {
 
     @Autowired

--- a/src/test/java/com/shiftsync/shiftsync/location/service/LocationServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/location/service/LocationServiceImplTest.java
@@ -2,11 +2,14 @@ package com.shiftsync.shiftsync.location.service;
 
 import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.location.dto.CreateLocationRequest;
 import com.shiftsync.shiftsync.location.dto.LocationResponse;
 import com.shiftsync.shiftsync.location.dto.UpdateLocationRequest;
 import com.shiftsync.shiftsync.location.entity.Location;
 import com.shiftsync.shiftsync.location.mapper.LocationMapper;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
 import com.shiftsync.shiftsync.location.repository.LocationRepository;
 import com.shiftsync.shiftsync.location.service.impl.LocationServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +36,12 @@ class LocationServiceImplTest {
     private LocationRepository locationRepository;
 
     @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private ManagerLocationRepository managerLocationRepository;
+
+    @Mock
     private LocationMapper locationMapper;
 
     @InjectMocks
@@ -40,6 +49,7 @@ class LocationServiceImplTest {
 
     private Location location;
     private LocationResponse response;
+    private Employee managerEmployee;
 
     @BeforeEach
     void setUp() {
@@ -58,6 +68,10 @@ class LocationServiceImplTest {
                 40,
                 true
         );
+
+        managerEmployee = Employee.builder()
+                .id(20L)
+                .build();
     }
 
     @Test
@@ -131,6 +145,38 @@ class LocationServiceImplTest {
         assertThatThrownBy(() -> locationService.updateLocation(1L, request))
                 .isInstanceOf(DuplicateResourceException.class)
                 .hasMessage("Location name already exists");
+    }
+
+    @Test
+    void getAssignedLocationsForManager_ReturnsEmptyListWhenNoAssignments() {
+        when(employeeRepository.findByUserId(99L)).thenReturn(Optional.of(managerEmployee));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(20L)).thenReturn(List.of());
+
+        List<LocationResponse> locations = locationService.getAssignedLocationsForManager(99L);
+
+        assertThat(locations).isEmpty();
+    }
+
+    @Test
+    void getAssignedLocationsForManager_ReturnsMappedLocations() {
+        when(employeeRepository.findByUserId(99L)).thenReturn(Optional.of(managerEmployee));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(20L)).thenReturn(List.of(1L));
+        when(locationRepository.findAllById(List.of(1L))).thenReturn(List.of(location));
+        when(locationMapper.toResponse(location)).thenReturn(response);
+
+        List<LocationResponse> locations = locationService.getAssignedLocationsForManager(99L);
+
+        assertThat(locations).hasSize(1);
+        assertThat(locations.getFirst().name()).isEqualTo("Airport Branch");
+    }
+
+    @Test
+    void getAssignedLocationsForManager_WhenManagerProfileMissing_ThrowsNotFound() {
+        when(employeeRepository.findByUserId(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> locationService.getAssignedLocationsForManager(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Manager profile not found");
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/location/service/LocationServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/location/service/LocationServiceImplTest.java
@@ -1,0 +1,136 @@
+package com.shiftsync.shiftsync.location.service;
+
+import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.location.dto.CreateLocationRequest;
+import com.shiftsync.shiftsync.location.dto.LocationResponse;
+import com.shiftsync.shiftsync.location.dto.UpdateLocationRequest;
+import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.location.mapper.LocationMapper;
+import com.shiftsync.shiftsync.location.repository.LocationRepository;
+import com.shiftsync.shiftsync.location.service.impl.LocationServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LocationServiceImplTest {
+
+    @Mock
+    private LocationRepository locationRepository;
+
+    @Mock
+    private LocationMapper locationMapper;
+
+    @InjectMocks
+    private LocationServiceImpl locationService;
+
+    private Location location;
+    private LocationResponse response;
+
+    @BeforeEach
+    void setUp() {
+        location = Location.builder()
+                .id(1L)
+                .name("Airport Branch")
+                .address("Airport Road")
+                .maxHeadcountPerShift(40)
+                .active(true)
+                .build();
+
+        response = new LocationResponse(
+                1L,
+                "Airport Branch",
+                "Airport Road",
+                40,
+                true
+        );
+    }
+
+    @Test
+    void createLocation_Success() {
+        CreateLocationRequest request = new CreateLocationRequest("Airport Branch", "Airport Road", 40);
+        when(locationRepository.existsByNameIgnoreCase("Airport Branch")).thenReturn(false);
+        when(locationRepository.save(any(Location.class))).thenReturn(location);
+        when(locationMapper.toResponse(location)).thenReturn(response);
+
+        LocationResponse created = locationService.createLocation(request);
+
+        assertThat(created.id()).isEqualTo(1L);
+        verify(locationRepository).save(any(Location.class));
+    }
+
+    @Test
+    void createLocation_DuplicateName_ThrowsConflict() {
+        CreateLocationRequest request = new CreateLocationRequest("Airport Branch", "Airport Road", 40);
+        when(locationRepository.existsByNameIgnoreCase("Airport Branch")).thenReturn(true);
+
+        assertThatThrownBy(() -> locationService.createLocation(request))
+                .isInstanceOf(DuplicateResourceException.class)
+                .hasMessage("Location name already exists");
+
+        verify(locationRepository, never()).save(any(Location.class));
+    }
+
+    @Test
+    void getActiveLocations_ReturnsMappedList() {
+        when(locationRepository.findAllByActiveTrue()).thenReturn(List.of(location));
+        when(locationMapper.toResponse(location)).thenReturn(response);
+
+        List<LocationResponse> locations = locationService.getActiveLocations();
+
+        assertThat(locations).hasSize(1);
+        assertThat(locations.getFirst().name()).isEqualTo("Airport Branch");
+    }
+
+    @Test
+    void updateLocation_Success() {
+        UpdateLocationRequest request = new UpdateLocationRequest("East Legon Branch", "Boundary Road", 55, true);
+        when(locationRepository.findById(1L)).thenReturn(Optional.of(location));
+        when(locationRepository.existsByNameIgnoreCaseAndIdNot("East Legon Branch", 1L)).thenReturn(false);
+        when(locationRepository.save(location)).thenReturn(location);
+        when(locationMapper.toResponse(location)).thenReturn(
+                new LocationResponse(1L, "East Legon Branch", "Boundary Road", 55, true)
+        );
+
+        LocationResponse updated = locationService.updateLocation(1L, request);
+
+        assertThat(updated.name()).isEqualTo("East Legon Branch");
+        assertThat(location.getAddress()).isEqualTo("Boundary Road");
+        assertThat(location.getMaxHeadcountPerShift()).isEqualTo(55);
+    }
+
+    @Test
+    void updateLocation_NotFound_ThrowsNotFound() {
+        when(locationRepository.findById(88L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> locationService.updateLocation(88L, new UpdateLocationRequest(null, null, null, null)))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Location not found");
+    }
+
+    @Test
+    void updateLocation_DuplicateName_ThrowsConflict() {
+        UpdateLocationRequest request = new UpdateLocationRequest("Airport Branch", null, null, null);
+        when(locationRepository.findById(1L)).thenReturn(Optional.of(location));
+        when(locationRepository.existsByNameIgnoreCaseAndIdNot("Airport Branch", 1L)).thenReturn(true);
+
+        assertThatThrownBy(() -> locationService.updateLocation(1L, request))
+                .isInstanceOf(DuplicateResourceException.class)
+                .hasMessage("Location name already exists");
+    }
+}
+


### PR DESCRIPTION
## What
Implements Epic 3 Location & Department Management:
- US-LOC-01 / FR-LOC-01: create, list active, and update locations
- US-LOC-02 / FR-LOC-02: create and list departments within a location
- US-LOC-03 / FR-LOC-03: get locations assigned to the authenticated manager

Implemented endpoints:
- POST /api/v1/locations
- GET /api/v1/locations
- PATCH /api/v1/locations/{id}
- POST /api/v1/locations/{locationId}/departments
- GET /api/v1/locations/{locationId}/departments
- GET /api/v1/managers/me/locations

## Why
ShiftSync needs location and department structures before scheduling logic can be scoped correctly by branch/site and work area.
Managers also need visibility into only their assigned locations so authorization boundaries are explicit and enforceable.

## How to test
1. Log in as HR_ADMIN and call `POST /api/v1/locations` with:
   - `name`, `address`, `maxHeadcountPerShift`
   - Expect `201`
2. Call `POST /api/v1/locations` again with same `name`
   - Expect `409` duplicate conflict
3. Call `GET /api/v1/locations`
   - Expect only active locations
4. Call `PATCH /api/v1/locations/{id}` as HR_ADMIN to update fields
   - Expect `200` and updated payload
5. Call `PATCH /api/v1/locations/{id}` as MANAGER or EMPLOYEE
   - Expect `403`
6. As HR_ADMIN, call `POST /api/v1/locations/{locationId}/departments` with `{ "name": "Kitchen" }`
   - Expect `201`
7. Repeat same department name for same location
   - Expect `409`
8. Call `POST /api/v1/locations/{invalidLocationId}/departments`
   - Expect `404`
9. Call `GET /api/v1/locations/{locationId}/departments`
   - Expect `200` with departments for that location
10. Log in as MANAGER and call `GET /api/v1/managers/me/locations`
    - If assigned: expect list of locations
    - If not assigned: expect `200` with `[]` (empty array)
11. Call `GET /api/v1/managers/me/locations` as EMPLOYEE
    - Expect `403`

## Notes
- Intentional API versioning is used: endpoints are under `/api/v1/...` instead of unversioned `/api/...`.
- This continues the existing project-wide versioned routing approach.
- Security model remains role-based: HR_ADMIN manages locations/departments; MANAGER reads assigned locations.
- Epic 3 includes controller/service tests for location and department flows (including auth and conflict paths).

<img width="1791" height="667" alt="image" src="https://github.com/user-attachments/assets/d11b6ca2-c3d0-4ea3-86c2-c1d686b5a2c3" />

