### PR TITLE
feat(authentication): implement password change on first login and add must_reset_password flag

### DIFF
--- a/src/main/java/com/shiftsync/shiftsync/auth/controller/AuthController.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.shiftsync.shiftsync.auth.controller;
 
 import com.shiftsync.shiftsync.auth.dto.AuthResponse;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordResponse;
 import com.shiftsync.shiftsync.auth.dto.LoginRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterResponse;
@@ -107,6 +109,35 @@ public class AuthController {
 
         String token = authHeader.substring(7);
         AuthResponse response = authService.refresh(token);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/change-password-first-login")
+    @Operation(
+            summary = "Change password on first login",
+            description = "Changes an HR-provisioned temporary password and clears the password reset flag."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Password changed successfully",
+                    content = @Content(schema = @Schema(implementation = ChangePasswordResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request parameters",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Invalid credentials or invalid first-login state",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<ChangePasswordResponse> changePasswordFirstLogin(
+            @Valid @RequestBody ChangePasswordRequest request
+    ) {
+        ChangePasswordResponse response = authService.changePasswordFirstLogin(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordRequest.java
@@ -2,6 +2,7 @@ package com.shiftsync.shiftsync.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record ChangePasswordRequest(
@@ -14,6 +15,10 @@ public record ChangePasswordRequest(
 
         @NotBlank(message = "New password is required")
         @Size(min = 8, message = "New password must be at least 8 characters")
+        @Pattern(
+                regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z\\d]).+$",
+                message = "New password must include uppercase, lowercase, number, and special character"
+        )
         String newPassword
 ) {
 }

--- a/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordRequest.java
@@ -1,0 +1,20 @@
+package com.shiftsync.shiftsync.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChangePasswordRequest(
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be valid")
+        String email,
+
+        @NotBlank(message = "Current password is required")
+        String currentPassword,
+
+        @NotBlank(message = "New password is required")
+        @Size(min = 8, message = "New password must be at least 8 characters")
+        String newPassword
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordResponse.java
@@ -1,0 +1,5 @@
+package com.shiftsync.shiftsync.auth.dto;
+
+public record ChangePasswordResponse(String message) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/dto/RegisterRequest.java
@@ -4,6 +4,7 @@ import com.shiftsync.shiftsync.common.enums.UserRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record RegisterRequest(
@@ -16,6 +17,10 @@ public record RegisterRequest(
 
         @NotBlank(message = "Password is required")
         @Size(min = 8, message = "Password must be at least 8 characters")
+        @Pattern(
+                regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z\\d]).+$",
+                message = "Password must include uppercase, lowercase, number, and special character"
+        )
         String password,
 
         @NotNull(message = "Role is required")

--- a/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
@@ -35,6 +35,7 @@ public class User {
     private UserRole role;
 
     @Column(name = "must_reset_password", nullable = false)
+    @Builder.Default
     private Boolean mustResetPassword = false;
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
@@ -35,7 +35,7 @@ public class User {
     private UserRole role;
 
     @Column(name = "must_reset_password", nullable = false)
-    private Boolean mustResetPassword;
+    private Boolean mustResetPassword = false;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
@@ -34,6 +34,9 @@ public class User {
     @Column(nullable = false)
     private UserRole role;
 
+    @Column(name = "must_reset_password", nullable = false)
+    private Boolean mustResetPassword;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -42,6 +45,9 @@ public class User {
 
     @PrePersist
     protected void onCreate() {
+        if (mustResetPassword == null) {
+            mustResetPassword = false;
+        }
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/shiftsync/shiftsync/auth/service/AuthService.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/service/AuthService.java
@@ -1,6 +1,8 @@
 package com.shiftsync.shiftsync.auth.service;
 
 import com.shiftsync.shiftsync.auth.dto.AuthResponse;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordResponse;
 import com.shiftsync.shiftsync.auth.dto.LoginRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterResponse;
@@ -32,4 +34,12 @@ public interface AuthService {
      * @return the auth response
      */
     AuthResponse refresh(String token);
+
+    /**
+     * Change password response.
+     *
+     * @param request the request
+     * @return the change password response
+     */
+    ChangePasswordResponse changePasswordFirstLogin(ChangePasswordRequest request);
 }

--- a/src/main/java/com/shiftsync/shiftsync/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/service/impl/AuthServiceImpl.java
@@ -99,13 +99,14 @@ public class AuthServiceImpl implements AuthService {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new UnauthorizedException("Invalid credentials"));
 
+        if (!Boolean.TRUE.equals(user.getMustResetPassword())) {
+            throw new UnauthorizedException("Invalid credentials");
+        }
+
         if (!passwordEncoder.matches(request.currentPassword(), user.getPasswordHash())) {
             throw new UnauthorizedException("Invalid credentials");
         }
 
-        if (!Boolean.TRUE.equals(user.getMustResetPassword())) {
-            throw new UnauthorizedException("Password reset is not required for this account");
-        }
 
         user.setPasswordHash(passwordEncoder.encode(request.newPassword()));
         user.setMustResetPassword(false);

--- a/src/main/java/com/shiftsync/shiftsync/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/service/impl/AuthServiceImpl.java
@@ -1,6 +1,8 @@
 package com.shiftsync.shiftsync.auth.service.impl;
 
 import com.shiftsync.shiftsync.auth.dto.AuthResponse;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordResponse;
 import com.shiftsync.shiftsync.auth.dto.LoginRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterResponse;
@@ -39,6 +41,7 @@ public class AuthServiceImpl implements AuthService {
                 .passwordHash(passwordEncoder.encode(request.password()))
                 .fullName(request.fullName())
                 .role(request.role())
+                .mustResetPassword(true)
                 .build();
 
         user = userRepository.save(user);
@@ -65,6 +68,10 @@ public class AuthServiceImpl implements AuthService {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new UnauthorizedException("Invalid credentials"));
 
+        if (Boolean.TRUE.equals(user.getMustResetPassword())) {
+            throw new UnauthorizedException("Password reset required before login");
+        }
+
 
         String token = jwtService.generateToken(user.getId(), user.getEmail(), user.getRole().name());
 
@@ -84,5 +91,26 @@ public class AuthServiceImpl implements AuthService {
         String newToken = jwtService.generateToken(user.getId(), user.getEmail(), user.getRole().name());
 
         return new AuthResponse(newToken, user.getId(), user.getEmail(), user.getFullName(), user.getRole());
+    }
+
+    @Override
+    @Transactional
+    public ChangePasswordResponse changePasswordFirstLogin(ChangePasswordRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new UnauthorizedException("Invalid credentials"));
+
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPasswordHash())) {
+            throw new UnauthorizedException("Invalid credentials");
+        }
+
+        if (!Boolean.TRUE.equals(user.getMustResetPassword())) {
+            throw new UnauthorizedException("Password reset is not required for this account");
+        }
+
+        user.setPasswordHash(passwordEncoder.encode(request.newPassword()));
+        user.setMustResetPassword(false);
+        userRepository.save(user);
+
+        return new ChangePasswordResponse("Password changed successfully. You can now log in.");
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/config/DataSeeder.java
+++ b/src/main/java/com/shiftsync/shiftsync/config/DataSeeder.java
@@ -42,13 +42,6 @@ public class DataSeeder {
 
                 userRepository.save(admin);
                 log.info("HR Admin user seeded: admin@shiftsync.com");
-            } else {
-                userRepository.findByEmail("admin@shiftsync.com").ifPresent(admin -> {
-                    if (!Boolean.TRUE.equals(admin.getMustResetPassword())) {
-                        admin.setMustResetPassword(true);
-                        userRepository.save(admin);
-                    }
-                });
             }
         };
     }

--- a/src/main/java/com/shiftsync/shiftsync/config/DataSeeder.java
+++ b/src/main/java/com/shiftsync/shiftsync/config/DataSeeder.java
@@ -38,9 +38,17 @@ public class DataSeeder {
                 admin.setPasswordHash(passwordEncoder.encode(adminPassword));
                 admin.setFullName("System Administrator");
                 admin.setRole(UserRole.HR_ADMIN);
+                admin.setMustResetPassword(true);
 
                 userRepository.save(admin);
                 log.info("HR Admin user seeded: admin@shiftsync.com");
+            } else {
+                userRepository.findByEmail("admin@shiftsync.com").ifPresent(admin -> {
+                    if (!Boolean.TRUE.equals(admin.getMustResetPassword())) {
+                        admin.setMustResetPassword(true);
+                        userRepository.save(admin);
+                    }
+                });
             }
         };
     }

--- a/src/main/java/com/shiftsync/shiftsync/config/security/SecurityConfig.java
+++ b/src/main/java/com/shiftsync/shiftsync/config/security/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
                         })
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/login", "/api/v1/auth/refresh").permitAll()
+                        .requestMatchers("/api/v1/auth/login", "/api/v1/auth/refresh", "/api/v1/auth/change-password-first-login").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").hasRole("HR_ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/v1/employees").hasRole("HR_ADMIN")

--- a/src/main/resources/db/changelog/changes/003-add-users-must-reset-password.xml
+++ b/src/main/resources/db/changelog/changes/003-add-users-must-reset-password.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <changeSet id="003-add-users-must-reset-password" author="shiftsync">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="users" columnName="must_reset_password"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="users">
+            <column name="must_reset_password" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="users" columnName="must_reset_password"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>
+

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -8,5 +8,6 @@
     <!-- Include your changesets here -->
     <include file="db/changelog/changes/001-initial-schema.xml"/>
     <include file="db/changelog/changes/002-add-employees-notification-enabled.xml"/>
+    <include file="db/changelog/changes/003-add-users-must-reset-password.xml"/>
 
 </databaseChangeLog>

--- a/src/test/java/com/shiftsync/shiftsync/auth/controller/AuthControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/auth/controller/AuthControllerWebMvcTest.java
@@ -2,6 +2,8 @@ package com.shiftsync.shiftsync.auth.controller;
 
 import com.shiftsync.shiftsync.auth.dto.LoginRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterRequest;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordResponse;
 import com.shiftsync.shiftsync.auth.service.AuthService;
 import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
 import com.shiftsync.shiftsync.common.exception.GlobalExceptionHandler;
@@ -173,6 +175,63 @@ class AuthControllerWebMvcTest {
                 .andExpect(jsonPath("$.message").value("Authorization header must contain a valid Bearer token"));
 
         verify(authService, never()).refresh(any(String.class));
+    }
+
+    @Test
+    void changePasswordFirstLogin_Success_ReturnsOk() throws Exception {
+        when(authService.changePasswordFirstLogin(any(ChangePasswordRequest.class)))
+                .thenReturn(new ChangePasswordResponse("Password changed successfully. You can now log in."));
+
+        String body = """
+                {
+                  "email": "test@shiftsync.com",
+                  "currentPassword": "Password@123",
+                  "newPassword": "NewPassword@123"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/change-password-first-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Password changed successfully. You can now log in."));
+    }
+
+    @Test
+    void changePasswordFirstLogin_BlankEmail_ReturnsBadRequest() throws Exception {
+        String body = """
+                {
+                  "email": "",
+                  "currentPassword": "Password@123",
+                  "newPassword": "NewPassword@123"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/change-password-first-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.email").value("Email is required"));
+    }
+
+    @Test
+    void changePasswordFirstLogin_InvalidCredentials_ReturnsUnauthorized() throws Exception {
+        when(authService.changePasswordFirstLogin(any(ChangePasswordRequest.class)))
+                .thenThrow(new BadCredentialsException("Bad credentials"));
+
+        String body = """
+                {
+                  "email": "test@shiftsync.com",
+                  "currentPassword": "WrongPassword",
+                  "newPassword": "NewPassword@123"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/change-password-first-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("Invalid credentials"));
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/auth/controller/AuthControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/auth/controller/AuthControllerWebMvcTest.java
@@ -215,6 +215,23 @@ class AuthControllerWebMvcTest {
     }
 
     @Test
+    void changePasswordFirstLogin_WeakNewPassword_ReturnsBadRequest() throws Exception {
+        String body = """
+                {
+                  "email": "test@shiftsync.com",
+                  "currentPassword": "Password@123",
+                  "newPassword": "password1"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/change-password-first-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.newPassword").value("New password must include uppercase, lowercase, number, and special character"));
+    }
+
+    @Test
     void changePasswordFirstLogin_InvalidCredentials_ReturnsUnauthorized() throws Exception {
         when(authService.changePasswordFirstLogin(any(ChangePasswordRequest.class)))
                 .thenThrow(new BadCredentialsException("Bad credentials"));

--- a/src/test/java/com/shiftsync/shiftsync/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/auth/service/AuthServiceImplTest.java
@@ -66,6 +66,7 @@ class AuthServiceImplTest {
                 .passwordHash("hashedPassword")
                 .fullName("Test User")
                 .role(UserRole.EMPLOYEE)
+                .mustResetPassword(true)
                 .build();
 
         registerRequest = new RegisterRequest(
@@ -93,6 +94,8 @@ class AuthServiceImplTest {
         assertThat(response.role()).isEqualTo(UserRole.EMPLOYEE);
         assertThat(response.message()).isEqualTo("User registered successfully");
 
+        verify(userRepository).save(argThat(saved -> Boolean.TRUE.equals(saved.getMustResetPassword())));
+
         verify(userRepository).existsByEmail(registerRequest.email());
         verify(passwordEncoder).encode(registerRequest.password());
         verify(userRepository).save(any(User.class));
@@ -112,6 +115,7 @@ class AuthServiceImplTest {
 
     @Test
     void login_Success() {
+        testUser.setMustResetPassword(false);
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
                 .thenReturn(authentication);
         when(userRepository.findByEmail(loginRequest.email())).thenReturn(Optional.of(testUser));
@@ -129,6 +133,54 @@ class AuthServiceImplTest {
         verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
         verify(userRepository).findByEmail("test@shiftsync.com");
         verify(jwtService).generateToken(1L, "test@shiftsync.com", "EMPLOYEE");
+    }
+
+    @Test
+    void login_PasswordResetRequired_ThrowsUnauthorizedException() {
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(authentication);
+        when(userRepository.findByEmail(loginRequest.email())).thenReturn(Optional.of(testUser));
+
+        assertThatThrownBy(() -> authService.login(loginRequest))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("Password reset required before login");
+
+        verify(jwtService, never()).generateToken(anyLong(), anyString(), anyString());
+    }
+
+    @Test
+    void changePasswordFirstLogin_Success() {
+        when(userRepository.findByEmail("test@shiftsync.com")).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.matches("Password@123", "hashedPassword")).thenReturn(true);
+        when(passwordEncoder.encode("NewPassword@123")).thenReturn("newHash");
+
+        var response = authService.changePasswordFirstLogin(
+                new com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest(
+                        "test@shiftsync.com",
+                        "Password@123",
+                        "NewPassword@123"
+                )
+        );
+
+        assertThat(response.message()).isEqualTo("Password changed successfully. You can now log in.");
+        assertThat(testUser.getMustResetPassword()).isFalse();
+        assertThat(testUser.getPasswordHash()).isEqualTo("newHash");
+        verify(userRepository).save(testUser);
+    }
+
+    @Test
+    void changePasswordFirstLogin_InvalidCurrentPassword_ThrowsUnauthorizedException() {
+        when(userRepository.findByEmail("test@shiftsync.com")).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.matches("WrongPassword", "hashedPassword")).thenReturn(false);
+
+        assertThatThrownBy(() -> authService.changePasswordFirstLogin(
+                new com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest(
+                        "test@shiftsync.com",
+                        "WrongPassword",
+                        "NewPassword@123"
+                )
+        )).isInstanceOf(UnauthorizedException.class)
+                .hasMessage("Invalid credentials");
     }
 
     @Test

--- a/src/test/java/com/shiftsync/shiftsync/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/auth/service/AuthServiceImplTest.java
@@ -184,6 +184,23 @@ class AuthServiceImplTest {
     }
 
     @Test
+    void changePasswordFirstLogin_WhenResetNotRequired_ThrowsUnauthorizedWithoutPasswordCheck() {
+        testUser.setMustResetPassword(false);
+        when(userRepository.findByEmail("test@shiftsync.com")).thenReturn(Optional.of(testUser));
+
+        assertThatThrownBy(() -> authService.changePasswordFirstLogin(
+                new com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest(
+                        "test@shiftsync.com",
+                        "Password@123",
+                        "NewPassword@123"
+                )
+        )).isInstanceOf(UnauthorizedException.class)
+                .hasMessage("Invalid credentials");
+
+        verify(passwordEncoder, never()).matches(anyString(), anyString());
+    }
+
+    @Test
     void login_InvalidCredentials_ThrowsUnauthorizedException() {
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
                 .thenThrow(new BadCredentialsException("Bad credentials"));


### PR DESCRIPTION
## What
Implements a first-login password reset enforcement flow for all HR-provisioned accounts (EMPLOYEE, MANAGER, and seeded HR_ADMIN), plus supporting auth hardening updates.

### Implemented changes
- Added `must_reset_password` to `users` via Liquibase migration:
  - `db/changelog/changes/003-add-users-must-reset-password.xml`
  - included in `db.changelog-master.xml`
- Updated `User` model to persist the reset flag.
- Updated registration flow so HR-created users are saved with `mustResetPassword=true`.
- Updated seeded admin behavior so seeded `HR_ADMIN` is also marked `mustResetPassword=true`.
- Updated login flow to block JWT issuance when `mustResetPassword=true`.
- Added first-login reset endpoint:
  - `POST /api/v1/auth/change-password-first-login`
- Added request/response DTOs for password change:
  - `ChangePasswordRequest`
  - `ChangePasswordResponse`
- Updated security config to allow first-login password change endpoint without JWT.
- Added/updated tests in:
  - `AuthServiceImplTest`
  - `AuthControllerWebMvcTest`
- Included controller quality fixes requested in review:
  - extracted shared auth principal parsing into `AuthenticationHelper`
  - added missing 400 validation tests for location/department create endpoints

## Why
This implements a security-hardening requirement for HR-provisioned credentials and aligns with:
- **FR-AUTH-03** (protected endpoint behavior and auth enforcement)
- **FR-AUTH-05** (secure credential handling)
- **NFR-03** (security: prevent unsafe credential usage)
- **NFR-04 / NFR-07** (validated input + consistent error responses)

Business need:
- HR initially sets temporary passwords for users.
- Users must replace temporary credentials at first login to ensure credential ownership and reduce account compromise risk.

## How to test
1. Start app with Liquibase enabled and ensure migration `003-add-users-must-reset-password` runs.
2. As HR_ADMIN, register an EMPLOYEE or MANAGER via `POST /api/v1/auth/register`.
3. Attempt login with created credentials via `POST /api/v1/auth/login`.
   - Expect `401` with message indicating password reset is required before login.
4. Call `POST /api/v1/auth/change-password-first-login` with:
   - `email`
   - `currentPassword` (temporary/HR-set password)
   - `newPassword`
   - Expect `200`.
5. Retry `POST /api/v1/auth/login` with the new password.
   - Expect `200` and JWT.
6. Verify seeded admin behavior:
   - login as seeded `admin@shiftsync.com` with seeded password should require first-login reset.
   - after reset endpoint success, login should return JWT.
7. Negative tests:
   - wrong current password on change endpoint -> `401`
   - invalid payload (e.g., blank email) -> `400` with field errors
   - unsupported auth header on refresh still returns expected `401`

## Notes
- **Intentional scope deviation**: first-login password reset flow was added even though it is not explicitly listed in the current user stories/workflow requirements.
- This deviation was discussed with Product Owner and **approved** for implementation due to security impact.
- API remains under `/api/v1/...` versioned routes (existing project convention).
