### PR TITLE
feat(manager-location): add endpoints to assign and unassign managers to locations

### DIFF
--- a/src/main/java/com/shiftsync/shiftsync/auth/controller/AuthController.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.shiftsync.shiftsync.auth.controller;
 
 import com.shiftsync.shiftsync.auth.dto.AuthResponse;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordResponse;
 import com.shiftsync.shiftsync.auth.dto.LoginRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterResponse;
@@ -107,6 +109,35 @@ public class AuthController {
 
         String token = authHeader.substring(7);
         AuthResponse response = authService.refresh(token);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/change-password-first-login")
+    @Operation(
+            summary = "Change password on first login",
+            description = "Changes an HR-provisioned temporary password and clears the password reset flag."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Password changed successfully",
+                    content = @Content(schema = @Schema(implementation = ChangePasswordResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request parameters",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "Invalid credentials or invalid first-login state",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    public ResponseEntity<ChangePasswordResponse> changePasswordFirstLogin(
+            @Valid @RequestBody ChangePasswordRequest request
+    ) {
+        ChangePasswordResponse response = authService.changePasswordFirstLogin(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordRequest.java
@@ -2,6 +2,7 @@ package com.shiftsync.shiftsync.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record ChangePasswordRequest(
@@ -14,6 +15,10 @@ public record ChangePasswordRequest(
 
         @NotBlank(message = "New password is required")
         @Size(min = 8, message = "New password must be at least 8 characters")
+        @Pattern(
+                regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z\\d]).+$",
+                message = "New password must include uppercase, lowercase, number, and special character"
+        )
         String newPassword
 ) {
 }

--- a/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordRequest.java
@@ -1,0 +1,20 @@
+package com.shiftsync.shiftsync.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChangePasswordRequest(
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be valid")
+        String email,
+
+        @NotBlank(message = "Current password is required")
+        String currentPassword,
+
+        @NotBlank(message = "New password is required")
+        @Size(min = 8, message = "New password must be at least 8 characters")
+        String newPassword
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/dto/ChangePasswordResponse.java
@@ -1,0 +1,5 @@
+package com.shiftsync.shiftsync.auth.dto;
+
+public record ChangePasswordResponse(String message) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/dto/RegisterRequest.java
@@ -4,6 +4,7 @@ import com.shiftsync.shiftsync.common.enums.UserRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record RegisterRequest(
@@ -16,6 +17,10 @@ public record RegisterRequest(
 
         @NotBlank(message = "Password is required")
         @Size(min = 8, message = "Password must be at least 8 characters")
+        @Pattern(
+                regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z\\d]).+$",
+                message = "Password must include uppercase, lowercase, number, and special character"
+        )
         String password,
 
         @NotNull(message = "Role is required")

--- a/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
@@ -35,6 +35,7 @@ public class User {
     private UserRole role;
 
     @Column(name = "must_reset_password", nullable = false)
+    @Builder.Default
     private Boolean mustResetPassword = false;
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
@@ -35,7 +35,7 @@ public class User {
     private UserRole role;
 
     @Column(name = "must_reset_password", nullable = false)
-    private Boolean mustResetPassword;
+    private Boolean mustResetPassword = false;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/entity/User.java
@@ -34,6 +34,9 @@ public class User {
     @Column(nullable = false)
     private UserRole role;
 
+    @Column(name = "must_reset_password", nullable = false)
+    private Boolean mustResetPassword;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -42,6 +45,9 @@ public class User {
 
     @PrePersist
     protected void onCreate() {
+        if (mustResetPassword == null) {
+            mustResetPassword = false;
+        }
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/shiftsync/shiftsync/auth/service/AuthService.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/service/AuthService.java
@@ -1,6 +1,8 @@
 package com.shiftsync.shiftsync.auth.service;
 
 import com.shiftsync.shiftsync.auth.dto.AuthResponse;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordResponse;
 import com.shiftsync.shiftsync.auth.dto.LoginRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterResponse;
@@ -32,4 +34,12 @@ public interface AuthService {
      * @return the auth response
      */
     AuthResponse refresh(String token);
+
+    /**
+     * Change password response.
+     *
+     * @param request the request
+     * @return the change password response
+     */
+    ChangePasswordResponse changePasswordFirstLogin(ChangePasswordRequest request);
 }

--- a/src/main/java/com/shiftsync/shiftsync/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/service/impl/AuthServiceImpl.java
@@ -99,13 +99,14 @@ public class AuthServiceImpl implements AuthService {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new UnauthorizedException("Invalid credentials"));
 
+        if (!Boolean.TRUE.equals(user.getMustResetPassword())) {
+            throw new UnauthorizedException("Invalid credentials");
+        }
+
         if (!passwordEncoder.matches(request.currentPassword(), user.getPasswordHash())) {
             throw new UnauthorizedException("Invalid credentials");
         }
 
-        if (!Boolean.TRUE.equals(user.getMustResetPassword())) {
-            throw new UnauthorizedException("Password reset is not required for this account");
-        }
 
         user.setPasswordHash(passwordEncoder.encode(request.newPassword()));
         user.setMustResetPassword(false);

--- a/src/main/java/com/shiftsync/shiftsync/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/auth/service/impl/AuthServiceImpl.java
@@ -1,6 +1,8 @@
 package com.shiftsync.shiftsync.auth.service.impl;
 
 import com.shiftsync.shiftsync.auth.dto.AuthResponse;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordResponse;
 import com.shiftsync.shiftsync.auth.dto.LoginRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterResponse;
@@ -39,6 +41,7 @@ public class AuthServiceImpl implements AuthService {
                 .passwordHash(passwordEncoder.encode(request.password()))
                 .fullName(request.fullName())
                 .role(request.role())
+                .mustResetPassword(true)
                 .build();
 
         user = userRepository.save(user);
@@ -65,6 +68,10 @@ public class AuthServiceImpl implements AuthService {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new UnauthorizedException("Invalid credentials"));
 
+        if (Boolean.TRUE.equals(user.getMustResetPassword())) {
+            throw new UnauthorizedException("Password reset required before login");
+        }
+
 
         String token = jwtService.generateToken(user.getId(), user.getEmail(), user.getRole().name());
 
@@ -84,5 +91,26 @@ public class AuthServiceImpl implements AuthService {
         String newToken = jwtService.generateToken(user.getId(), user.getEmail(), user.getRole().name());
 
         return new AuthResponse(newToken, user.getId(), user.getEmail(), user.getFullName(), user.getRole());
+    }
+
+    @Override
+    @Transactional
+    public ChangePasswordResponse changePasswordFirstLogin(ChangePasswordRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new UnauthorizedException("Invalid credentials"));
+
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPasswordHash())) {
+            throw new UnauthorizedException("Invalid credentials");
+        }
+
+        if (!Boolean.TRUE.equals(user.getMustResetPassword())) {
+            throw new UnauthorizedException("Password reset is not required for this account");
+        }
+
+        user.setPasswordHash(passwordEncoder.encode(request.newPassword()));
+        user.setMustResetPassword(false);
+        userRepository.save(user);
+
+        return new ChangePasswordResponse("Password changed successfully. You can now log in.");
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/config/DataSeeder.java
+++ b/src/main/java/com/shiftsync/shiftsync/config/DataSeeder.java
@@ -42,13 +42,6 @@ public class DataSeeder {
 
                 userRepository.save(admin);
                 log.info("HR Admin user seeded: admin@shiftsync.com");
-            } else {
-                userRepository.findByEmail("admin@shiftsync.com").ifPresent(admin -> {
-                    if (!Boolean.TRUE.equals(admin.getMustResetPassword())) {
-                        admin.setMustResetPassword(true);
-                        userRepository.save(admin);
-                    }
-                });
             }
         };
     }

--- a/src/main/java/com/shiftsync/shiftsync/config/DataSeeder.java
+++ b/src/main/java/com/shiftsync/shiftsync/config/DataSeeder.java
@@ -38,9 +38,17 @@ public class DataSeeder {
                 admin.setPasswordHash(passwordEncoder.encode(adminPassword));
                 admin.setFullName("System Administrator");
                 admin.setRole(UserRole.HR_ADMIN);
+                admin.setMustResetPassword(true);
 
                 userRepository.save(admin);
                 log.info("HR Admin user seeded: admin@shiftsync.com");
+            } else {
+                userRepository.findByEmail("admin@shiftsync.com").ifPresent(admin -> {
+                    if (!Boolean.TRUE.equals(admin.getMustResetPassword())) {
+                        admin.setMustResetPassword(true);
+                        userRepository.save(admin);
+                    }
+                });
             }
         };
     }

--- a/src/main/java/com/shiftsync/shiftsync/config/security/SecurityConfig.java
+++ b/src/main/java/com/shiftsync/shiftsync/config/security/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
                         })
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/login", "/api/v1/auth/refresh").permitAll()
+                        .requestMatchers("/api/v1/auth/login", "/api/v1/auth/refresh", "/api/v1/auth/change-password-first-login").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").hasRole("HR_ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/v1/employees").hasRole("HR_ADMIN")

--- a/src/main/java/com/shiftsync/shiftsync/location/controller/ManagerLocationController.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/controller/ManagerLocationController.java
@@ -13,16 +13,20 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.DeleteMapping;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/managers/me")
+@RequestMapping("/api/v1/managers")
 @RequiredArgsConstructor
 @Tag(name = "Manager Locations", description = "Manager location assignment endpoints")
 public class ManagerLocationController {
@@ -30,7 +34,7 @@ public class ManagerLocationController {
     private final LocationService locationService;
     private final AuthenticationHelper authenticationHelper;
 
-    @GetMapping("/locations")
+    @GetMapping("/me/locations")
     @PreAuthorize("hasRole('MANAGER')")
     @Operation(
             summary = "Get assigned locations",
@@ -44,6 +48,46 @@ public class ManagerLocationController {
     public ResponseEntity<List<LocationResponse>> getMyAssignedLocations(Authentication authentication) {
         Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
         return ResponseEntity.ok(locationService.getAssignedLocationsForManager(actorUserId));
+    }
+
+    @PostMapping("/{managerEmployeeId}/locations/{locationId}")
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(
+            summary = "Assign manager to location",
+            description = "Assigns a manager employee profile to a location."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Manager assigned to location"),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Manager or location not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Invalid state or duplicate assignment", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> assignManagerToLocation(
+            @PathVariable Long managerEmployeeId,
+            @PathVariable Long locationId
+    ) {
+        locationService.assignManagerToLocation(managerEmployeeId, locationId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/{managerEmployeeId}/locations/{locationId}")
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(
+            summary = "Unassign manager from location",
+            description = "Removes a manager-location assignment."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Manager unassigned from location"),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Manager, location, or assignment not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Invalid state", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> unassignManagerFromLocation(
+            @PathVariable Long managerEmployeeId,
+            @PathVariable Long locationId
+    ) {
+        locationService.unassignManagerFromLocation(managerEmployeeId, locationId);
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/location/repository/ManagerLocationRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/repository/ManagerLocationRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The interface Manager location repository.
@@ -21,5 +22,23 @@ public interface ManagerLocationRepository extends JpaRepository<ManagerLocation
      */
     @Query("select ml.location.id from ManagerLocation ml where ml.manager.id = :managerEmployeeId")
     List<Long> findLocationIdsByManagerEmployeeId(Long managerEmployeeId);
+
+    /**
+     * Exists by manager id and location id boolean.
+     *
+     * @param managerId  the manager id
+     * @param locationId the location id
+     * @return the boolean
+     */
+    boolean existsByManagerIdAndLocationId(Long managerId, Long locationId);
+
+    /**
+     * Find by manager id and location id optional.
+     *
+     * @param managerId  the manager id
+     * @param locationId the location id
+     * @return the optional
+     */
+    Optional<ManagerLocation> findByManagerIdAndLocationId(Long managerId, Long locationId);
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/location/service/LocationService.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/service/LocationService.java
@@ -35,6 +35,22 @@ public interface LocationService {
     List<LocationResponse> getAssignedLocationsForManager(Long actorUserId);
 
     /**
+     * Assign manager to location.
+     *
+     * @param managerEmployeeId the manager employee id
+     * @param locationId        the location id
+     */
+    void assignManagerToLocation(Long managerEmployeeId, Long locationId);
+
+    /**
+     * Unassign manager from location.
+     *
+     * @param managerEmployeeId the manager employee id
+     * @param locationId        the location id
+     */
+    void unassignManagerFromLocation(Long managerEmployeeId, Long locationId);
+
+    /**
      * Update location location response.
      *
      * @param locationId the location id

--- a/src/main/java/com/shiftsync/shiftsync/location/service/impl/LocationServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/service/impl/LocationServiceImpl.java
@@ -1,11 +1,14 @@
 package com.shiftsync.shiftsync.location.service.impl;
 
 import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.common.enums.UserRole;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.location.dto.CreateLocationRequest;
 import com.shiftsync.shiftsync.location.dto.LocationResponse;
+import com.shiftsync.shiftsync.location.entity.ManagerLocation;
 import com.shiftsync.shiftsync.location.dto.UpdateLocationRequest;
 import com.shiftsync.shiftsync.location.entity.Location;
 import com.shiftsync.shiftsync.location.mapper.LocationMapper;
@@ -69,6 +72,50 @@ public class LocationServiceImpl implements LocationService {
                 .stream()
                 .map(locationMapper::toResponse)
                 .toList();
+    }
+
+    @Override
+    @Transactional
+    public void assignManagerToLocation(Long managerEmployeeId, Long locationId) {
+        Employee manager = employeeRepository.findById(managerEmployeeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Manager not found"));
+
+        if (!UserRole.MANAGER.equals(manager.getUser().getRole())) {
+            throw new InvalidStateException("Employee is not a manager");
+        }
+
+        Location location = locationRepository.findById(locationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Location not found"));
+
+        if (managerLocationRepository.existsByManagerIdAndLocationId(managerEmployeeId, locationId)) {
+            throw new DuplicateResourceException("Manager is already assigned to this location");
+        }
+
+        managerLocationRepository.save(
+                ManagerLocation.builder()
+                        .manager(manager)
+                        .location(location)
+                        .build()
+        );
+    }
+
+    @Override
+    @Transactional
+    public void unassignManagerFromLocation(Long managerEmployeeId, Long locationId) {
+        Employee manager = employeeRepository.findById(managerEmployeeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Manager not found"));
+
+        if (!UserRole.MANAGER.equals(manager.getUser().getRole())) {
+            throw new InvalidStateException("Employee is not a manager");
+        }
+
+        locationRepository.findById(locationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Location not found"));
+
+        ManagerLocation managerLocation = managerLocationRepository.findByManagerIdAndLocationId(managerEmployeeId, locationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Manager assignment not found"));
+
+        managerLocationRepository.delete(managerLocation);
     }
 
     @Override

--- a/src/main/resources/db/changelog/changes/003-add-users-must-reset-password.xml
+++ b/src/main/resources/db/changelog/changes/003-add-users-must-reset-password.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <changeSet id="003-add-users-must-reset-password" author="shiftsync">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="users" columnName="must_reset_password"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="users">
+            <column name="must_reset_password" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="users" columnName="must_reset_password"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>
+

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -8,5 +8,6 @@
     <!-- Include your changesets here -->
     <include file="db/changelog/changes/001-initial-schema.xml"/>
     <include file="db/changelog/changes/002-add-employees-notification-enabled.xml"/>
+    <include file="db/changelog/changes/003-add-users-must-reset-password.xml"/>
 
 </databaseChangeLog>

--- a/src/test/java/com/shiftsync/shiftsync/auth/controller/AuthControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/auth/controller/AuthControllerWebMvcTest.java
@@ -2,6 +2,8 @@ package com.shiftsync.shiftsync.auth.controller;
 
 import com.shiftsync.shiftsync.auth.dto.LoginRequest;
 import com.shiftsync.shiftsync.auth.dto.RegisterRequest;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest;
+import com.shiftsync.shiftsync.auth.dto.ChangePasswordResponse;
 import com.shiftsync.shiftsync.auth.service.AuthService;
 import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
 import com.shiftsync.shiftsync.common.exception.GlobalExceptionHandler;
@@ -173,6 +175,63 @@ class AuthControllerWebMvcTest {
                 .andExpect(jsonPath("$.message").value("Authorization header must contain a valid Bearer token"));
 
         verify(authService, never()).refresh(any(String.class));
+    }
+
+    @Test
+    void changePasswordFirstLogin_Success_ReturnsOk() throws Exception {
+        when(authService.changePasswordFirstLogin(any(ChangePasswordRequest.class)))
+                .thenReturn(new ChangePasswordResponse("Password changed successfully. You can now log in."));
+
+        String body = """
+                {
+                  "email": "test@shiftsync.com",
+                  "currentPassword": "Password@123",
+                  "newPassword": "NewPassword@123"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/change-password-first-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Password changed successfully. You can now log in."));
+    }
+
+    @Test
+    void changePasswordFirstLogin_BlankEmail_ReturnsBadRequest() throws Exception {
+        String body = """
+                {
+                  "email": "",
+                  "currentPassword": "Password@123",
+                  "newPassword": "NewPassword@123"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/change-password-first-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.email").value("Email is required"));
+    }
+
+    @Test
+    void changePasswordFirstLogin_InvalidCredentials_ReturnsUnauthorized() throws Exception {
+        when(authService.changePasswordFirstLogin(any(ChangePasswordRequest.class)))
+                .thenThrow(new BadCredentialsException("Bad credentials"));
+
+        String body = """
+                {
+                  "email": "test@shiftsync.com",
+                  "currentPassword": "WrongPassword",
+                  "newPassword": "NewPassword@123"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/change-password-first-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("Invalid credentials"));
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/auth/controller/AuthControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/auth/controller/AuthControllerWebMvcTest.java
@@ -215,6 +215,23 @@ class AuthControllerWebMvcTest {
     }
 
     @Test
+    void changePasswordFirstLogin_WeakNewPassword_ReturnsBadRequest() throws Exception {
+        String body = """
+                {
+                  "email": "test@shiftsync.com",
+                  "currentPassword": "Password@123",
+                  "newPassword": "password1"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/auth/change-password-first-login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.fieldErrors.newPassword").value("New password must include uppercase, lowercase, number, and special character"));
+    }
+
+    @Test
     void changePasswordFirstLogin_InvalidCredentials_ReturnsUnauthorized() throws Exception {
         when(authService.changePasswordFirstLogin(any(ChangePasswordRequest.class)))
                 .thenThrow(new BadCredentialsException("Bad credentials"));

--- a/src/test/java/com/shiftsync/shiftsync/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/auth/service/AuthServiceImplTest.java
@@ -66,6 +66,7 @@ class AuthServiceImplTest {
                 .passwordHash("hashedPassword")
                 .fullName("Test User")
                 .role(UserRole.EMPLOYEE)
+                .mustResetPassword(true)
                 .build();
 
         registerRequest = new RegisterRequest(
@@ -93,6 +94,8 @@ class AuthServiceImplTest {
         assertThat(response.role()).isEqualTo(UserRole.EMPLOYEE);
         assertThat(response.message()).isEqualTo("User registered successfully");
 
+        verify(userRepository).save(argThat(saved -> Boolean.TRUE.equals(saved.getMustResetPassword())));
+
         verify(userRepository).existsByEmail(registerRequest.email());
         verify(passwordEncoder).encode(registerRequest.password());
         verify(userRepository).save(any(User.class));
@@ -112,6 +115,7 @@ class AuthServiceImplTest {
 
     @Test
     void login_Success() {
+        testUser.setMustResetPassword(false);
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
                 .thenReturn(authentication);
         when(userRepository.findByEmail(loginRequest.email())).thenReturn(Optional.of(testUser));
@@ -129,6 +133,54 @@ class AuthServiceImplTest {
         verify(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
         verify(userRepository).findByEmail("test@shiftsync.com");
         verify(jwtService).generateToken(1L, "test@shiftsync.com", "EMPLOYEE");
+    }
+
+    @Test
+    void login_PasswordResetRequired_ThrowsUnauthorizedException() {
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(authentication);
+        when(userRepository.findByEmail(loginRequest.email())).thenReturn(Optional.of(testUser));
+
+        assertThatThrownBy(() -> authService.login(loginRequest))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessage("Password reset required before login");
+
+        verify(jwtService, never()).generateToken(anyLong(), anyString(), anyString());
+    }
+
+    @Test
+    void changePasswordFirstLogin_Success() {
+        when(userRepository.findByEmail("test@shiftsync.com")).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.matches("Password@123", "hashedPassword")).thenReturn(true);
+        when(passwordEncoder.encode("NewPassword@123")).thenReturn("newHash");
+
+        var response = authService.changePasswordFirstLogin(
+                new com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest(
+                        "test@shiftsync.com",
+                        "Password@123",
+                        "NewPassword@123"
+                )
+        );
+
+        assertThat(response.message()).isEqualTo("Password changed successfully. You can now log in.");
+        assertThat(testUser.getMustResetPassword()).isFalse();
+        assertThat(testUser.getPasswordHash()).isEqualTo("newHash");
+        verify(userRepository).save(testUser);
+    }
+
+    @Test
+    void changePasswordFirstLogin_InvalidCurrentPassword_ThrowsUnauthorizedException() {
+        when(userRepository.findByEmail("test@shiftsync.com")).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.matches("WrongPassword", "hashedPassword")).thenReturn(false);
+
+        assertThatThrownBy(() -> authService.changePasswordFirstLogin(
+                new com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest(
+                        "test@shiftsync.com",
+                        "WrongPassword",
+                        "NewPassword@123"
+                )
+        )).isInstanceOf(UnauthorizedException.class)
+                .hasMessage("Invalid credentials");
     }
 
     @Test

--- a/src/test/java/com/shiftsync/shiftsync/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/auth/service/AuthServiceImplTest.java
@@ -184,6 +184,23 @@ class AuthServiceImplTest {
     }
 
     @Test
+    void changePasswordFirstLogin_WhenResetNotRequired_ThrowsUnauthorizedWithoutPasswordCheck() {
+        testUser.setMustResetPassword(false);
+        when(userRepository.findByEmail("test@shiftsync.com")).thenReturn(Optional.of(testUser));
+
+        assertThatThrownBy(() -> authService.changePasswordFirstLogin(
+                new com.shiftsync.shiftsync.auth.dto.ChangePasswordRequest(
+                        "test@shiftsync.com",
+                        "Password@123",
+                        "NewPassword@123"
+                )
+        )).isInstanceOf(UnauthorizedException.class)
+                .hasMessage("Invalid credentials");
+
+        verify(passwordEncoder, never()).matches(anyString(), anyString());
+    }
+
+    @Test
     void login_InvalidCredentials_ThrowsUnauthorizedException() {
         when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
                 .thenThrow(new BadCredentialsException("Bad credentials"));

--- a/src/test/java/com/shiftsync/shiftsync/location/controller/ManagerLocationControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/location/controller/ManagerLocationControllerWebMvcTest.java
@@ -19,7 +19,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -74,6 +76,34 @@ class ManagerLocationControllerWebMvcTest {
     @WithMockUser(username = "11", roles = "EMPLOYEE")
     void getMyAssignedLocations_WrongRole_ReturnsForbidden() throws Exception {
         mockMvc.perform(get("/api/v1/managers/me/locations"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void assignManagerToLocation_HrAdmin_ReturnsCreated() throws Exception {
+        mockMvc.perform(post("/api/v1/managers/20/locations/1"))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithMockUser(roles = "MANAGER")
+    void assignManagerToLocation_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(post("/api/v1/managers/20/locations/1"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void unassignManagerFromLocation_HrAdmin_ReturnsNoContent() throws Exception {
+        mockMvc.perform(delete("/api/v1/managers/20/locations/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(roles = "MANAGER")
+    void unassignManagerFromLocation_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(delete("/api/v1/managers/20/locations/1"))
                 .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/com/shiftsync/shiftsync/location/service/LocationServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/location/service/LocationServiceImplTest.java
@@ -1,6 +1,10 @@
 package com.shiftsync.shiftsync.location.service;
 
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.common.enums.UserRole;
 import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
@@ -8,6 +12,7 @@ import com.shiftsync.shiftsync.location.dto.CreateLocationRequest;
 import com.shiftsync.shiftsync.location.dto.LocationResponse;
 import com.shiftsync.shiftsync.location.dto.UpdateLocationRequest;
 import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.location.entity.ManagerLocation;
 import com.shiftsync.shiftsync.location.mapper.LocationMapper;
 import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
 import com.shiftsync.shiftsync.location.repository.LocationRepository;
@@ -50,6 +55,7 @@ class LocationServiceImplTest {
     private Location location;
     private LocationResponse response;
     private Employee managerEmployee;
+    private User managerUser;
 
     @BeforeEach
     void setUp() {
@@ -71,7 +77,15 @@ class LocationServiceImplTest {
 
         managerEmployee = Employee.builder()
                 .id(20L)
+                .user(managerUser)
                 .build();
+
+        managerUser = User.builder()
+                .id(50L)
+                .role(UserRole.MANAGER)
+                .build();
+
+        managerEmployee.setUser(managerUser);
     }
 
     @Test
@@ -177,6 +191,65 @@ class LocationServiceImplTest {
         assertThatThrownBy(() -> locationService.getAssignedLocationsForManager(99L))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("Manager profile not found");
+    }
+
+    @Test
+    void assignManagerToLocation_Success() {
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(managerEmployee));
+        when(locationRepository.findById(1L)).thenReturn(Optional.of(location));
+        when(managerLocationRepository.existsByManagerIdAndLocationId(20L, 1L)).thenReturn(false);
+
+        locationService.assignManagerToLocation(20L, 1L);
+
+        verify(managerLocationRepository).save(any(ManagerLocation.class));
+    }
+
+    @Test
+    void assignManagerToLocation_DuplicateAssignment_ThrowsConflict() {
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(managerEmployee));
+        when(locationRepository.findById(1L)).thenReturn(Optional.of(location));
+        when(managerLocationRepository.existsByManagerIdAndLocationId(20L, 1L)).thenReturn(true);
+
+        assertThatThrownBy(() -> locationService.assignManagerToLocation(20L, 1L))
+                .isInstanceOf(DuplicateResourceException.class)
+                .hasMessage("Manager is already assigned to this location");
+    }
+
+    @Test
+    void assignManagerToLocation_NotManager_ThrowsInvalidState() {
+        managerUser.setRole(UserRole.EMPLOYEE);
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(managerEmployee));
+
+        assertThatThrownBy(() -> locationService.assignManagerToLocation(20L, 1L))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Employee is not a manager");
+    }
+
+    @Test
+    void unassignManagerFromLocation_Success() {
+        ManagerLocation mapping = ManagerLocation.builder()
+                .id(5L)
+                .manager(managerEmployee)
+                .location(location)
+                .build();
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(managerEmployee));
+        when(locationRepository.findById(1L)).thenReturn(Optional.of(location));
+        when(managerLocationRepository.findByManagerIdAndLocationId(20L, 1L)).thenReturn(Optional.of(mapping));
+
+        locationService.unassignManagerFromLocation(20L, 1L);
+
+        verify(managerLocationRepository).delete(mapping);
+    }
+
+    @Test
+    void unassignManagerFromLocation_MissingAssignment_ThrowsNotFound() {
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(managerEmployee));
+        when(locationRepository.findById(1L)).thenReturn(Optional.of(location));
+        when(managerLocationRepository.findByManagerIdAndLocationId(20L, 1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> locationService.unassignManagerFromLocation(20L, 1L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Manager assignment not found");
     }
 }
 


### PR DESCRIPTION
## What
Implements Epic 3 location/department management and related auth/security hardening needed for operability.

### Delivered in this PR
- **US-LOC-01 / FR-LOC-01**
  - `POST /api/v1/locations` (HR_ADMIN)
  - `GET /api/v1/locations` (active locations)
  - `PATCH /api/v1/locations/{id}` (HR_ADMIN)
  - Duplicate location name handling (`409`)
- **US-LOC-02 / FR-LOC-02**
  - `POST /api/v1/locations/{locationId}/departments` (HR_ADMIN)
  - `GET /api/v1/locations/{locationId}/departments` (HR_ADMIN, MANAGER)
  - Department uniqueness scoped to location (`409`)
  - `404` for invalid `locationId`
- **US-LOC-03 / FR-LOC-03**
  - `GET /api/v1/managers/me/locations` (MANAGER)
  - Returns empty list when no assignments
- **Operational extension to close assignment gap in FR-LOC-03**
  - `POST /api/v1/managers/{managerEmployeeId}/locations/{locationId}` (HR_ADMIN) assign
  - `DELETE /api/v1/managers/{managerEmployeeId}/locations/{locationId}` (HR_ADMIN) unassign
- **Auth/security hardening implemented in this branch**
  - First-login password reset enforcement via `users.must_reset_password`
  - Liquibase migration: `003-add-users-must-reset-password.xml`
  - Endpoint: `POST /api/v1/auth/change-password-first-login`
  - Login blocked until reset when `must_reset_password=true`
  - Seeded HR admin is created with reset-required flag
  - Password complexity aligned across register and first-login reset
- **Code quality / review follow-ups**
  - Extracted duplicated principal parsing into shared `AuthenticationHelper`
  - Added missing 400 validation tests for location/department create endpoints

## Why
- Epic 3 requires location and department management plus manager location visibility:
  - `US-LOC-01`, `US-LOC-02`, `US-LOC-03`
  - `FR-LOC-01`, `FR-LOC-02`, `FR-LOC-03`
- `FR-LOC-03` states managers are assigned to locations, but assignment workflow was not explicitly defined in stories.  
  To make manager scoping usable end-to-end (and unblock downstream scheduling flows), HR assign/unassign endpoints were added.
- First-login reset flow was added to secure HR-provisioned credentials and seeded admin credentials.

## How to test
1. **Locations**
   - Login as HR_ADMIN
   - `POST /api/v1/locations` with `{name,address,maxHeadcountPerShift}` -> `201`
   - Repeat with same name -> `409`
   - `GET /api/v1/locations` -> `200`, active locations only
   - `PATCH /api/v1/locations/{id}` -> `200`
2. **Departments**
   - As HR_ADMIN: `POST /api/v1/locations/{locationId}/departments` with `{name}` -> `201`
   - Duplicate name in same location -> `409`
   - Invalid location -> `404`
   - As MANAGER: `GET /api/v1/locations/{locationId}/departments` -> `200`
3. **Manager assignments**
   - As HR_ADMIN: `POST /api/v1/managers/{managerEmployeeId}/locations/{locationId}` -> `201`
   - Duplicate assign -> `409`
   - As HR_ADMIN: `DELETE /api/v1/managers/{managerEmployeeId}/locations/{locationId}` -> `204`
   - Missing assignment on delete -> `404`
   - As MANAGER: `GET /api/v1/managers/me/locations` -> `200` with assigned list or `[]`
4. **First-login reset**
   - Create user via HR register or use seeded admin
   - Attempt login before reset -> blocked (reset required)
   - `POST /api/v1/auth/change-password-first-login` with valid current/new password -> `200`
   - Login with new password -> `200` + JWT
5. **Validation checks**
   - Create location with blank `name` -> `400` with `fieldErrors.name`
   - Create department with blank `name` -> `400` with `fieldErrors.name`
   - Weak new password on first-login reset -> `400` with `fieldErrors.newPassword`

## Notes
- **Gap addressed:** `FR-LOC-03` required manager-location assignment conceptually, but no explicit assignment story/endpoint was provided.  
  Added HR assign/unassign endpoints to make Epic 3 usable in practice and to avoid manual DB provisioning.
- **Approved scope deviation:** first-login password reset flow (`must_reset_password` + reset endpoint) was added though not explicitly listed in current stories, due to security requirements for HR-provisioned credentials and seeded admin credentials.
- **API versioning deviation maintained:** routes use `/api/v1/...` (not unversioned `/api/...`) to stay consistent with current project convention.
