### PR TITLE
feat: implement availability management (US-AVAIL-01..04)

### DIFF
--- a/src/main/java/com/shiftsync/shiftsync/availability/controller/AvailabilityController.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/controller/AvailabilityController.java
@@ -93,7 +93,7 @@ public class AvailabilityController {
     @PreAuthorize("hasRole('EMPLOYEE')")
     @Operation(
             summary = "List active availability overrides",
-            description = "Lists active one-off unavailability overrides for the authenticated employee."
+            description = "Lists one-off unavailability overrides that are currently active or scheduled for future dates."
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Active overrides retrieved", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AvailabilityOverrideResponse.class)))),

--- a/src/main/java/com/shiftsync/shiftsync/availability/controller/AvailabilityController.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/controller/AvailabilityController.java
@@ -1,0 +1,57 @@
+package com.shiftsync.shiftsync.availability.controller;
+
+import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityItemRequest;
+import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
+import com.shiftsync.shiftsync.availability.service.AvailabilityService;
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/employees/me/availability")
+@RequiredArgsConstructor
+@Tag(name = "Availability", description = "Employee availability management endpoints")
+public class AvailabilityController {
+
+    private final AvailabilityService availabilityService;
+    private final AuthenticationHelper authenticationHelper;
+
+    @PutMapping("/recurring")
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    @Operation(
+            summary = "Replace recurring weekly availability",
+            description = "Replaces recurring weekly availability windows. Empty list clears all windows."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Recurring availability saved", content = @Content(array = @ArraySchema(schema = @Schema(implementation = RecurringAvailabilityResponse.class)))),
+            @ApiResponse(responseCode = "400", description = "Invalid request or overlapping windows", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<RecurringAvailabilityResponse>> replaceRecurringAvailability(
+            Authentication authentication,
+            @Valid @RequestBody List<@Valid RecurringAvailabilityItemRequest> windows
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        List<RecurringAvailabilityResponse> response = availabilityService.replaceRecurringAvailability(actorUserId, windows);
+        return ResponseEntity.ok(response);
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/controller/AvailabilityController.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/controller/AvailabilityController.java
@@ -1,5 +1,7 @@
 package com.shiftsync.shiftsync.availability.controller;
 
+import com.shiftsync.shiftsync.availability.dto.AvailabilityOverrideResponse;
+import com.shiftsync.shiftsync.availability.dto.CreateAvailabilityOverrideRequest;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityItemRequest;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
 import com.shiftsync.shiftsync.availability.service.AvailabilityService;
@@ -17,10 +19,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.List;
 
@@ -52,6 +59,71 @@ public class AvailabilityController {
         Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
         List<RecurringAvailabilityResponse> response = availabilityService.replaceRecurringAvailability(actorUserId, windows);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/overrides")
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    @Operation(
+            summary = "Create one-off availability override",
+            description = "Creates a one-off unavailability date block for the authenticated employee."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Override created", content = @Content(schema = @Schema(implementation = AvailabilityOverrideResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Overlapping override dates", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<AvailabilityOverrideResponse> createOverride(
+            Authentication authentication,
+            @Valid @RequestBody CreateAvailabilityOverrideRequest request
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        AvailabilityOverrideResponse response = availabilityService.createOverride(actorUserId, request);
+
+        return ResponseEntity
+                .created(ServletUriComponentsBuilder.fromCurrentRequest()
+                        .path("/{id}")
+                        .buildAndExpand(response.id())
+                        .toUri())
+                .body(response);
+    }
+
+    @GetMapping("/overrides")
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    @Operation(
+            summary = "List active availability overrides",
+            description = "Lists active one-off unavailability overrides for the authenticated employee."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Active overrides retrieved", content = @Content(array = @ArraySchema(schema = @Schema(implementation = AvailabilityOverrideResponse.class)))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<AvailabilityOverrideResponse>> listActiveOverrides(Authentication authentication) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        return ResponseEntity.ok(availabilityService.listActiveOverrides(actorUserId));
+    }
+
+    @DeleteMapping("/overrides/{overrideId}")
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    @Operation(
+            summary = "Delete availability override",
+            description = "Deletes a one-off unavailability override that belongs to the authenticated employee."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Override deleted"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Override not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> deleteOverride(
+            Authentication authentication,
+            @PathVariable Long overrideId
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        availabilityService.deleteOverride(actorUserId, overrideId);
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/availability/controller/ManagerAvailabilityController.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/controller/ManagerAvailabilityController.java
@@ -1,0 +1,58 @@
+package com.shiftsync.shiftsync.availability.controller;
+
+import com.shiftsync.shiftsync.availability.dto.ManagerWeeklyAvailabilityResponse;
+import com.shiftsync.shiftsync.availability.service.AvailabilityService;
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/v1/locations")
+@RequiredArgsConstructor
+@Tag(name = "Manager Availability", description = "Manager team availability endpoints")
+public class ManagerAvailabilityController {
+
+    private final AvailabilityService availabilityService;
+    private final AuthenticationHelper authenticationHelper;
+
+    @GetMapping("/{locationId}/availability")
+    @PreAuthorize("hasRole('MANAGER')")
+    @Operation(
+            summary = "Get weekly team availability",
+            description = "Returns per-employee availability for the requested week at a manager-assigned location."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Weekly availability retrieved", content = @Content(schema = @Schema(implementation = ManagerWeeklyAvailabilityResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid week parameter", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Manager not assigned to location", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<ManagerWeeklyAvailabilityResponse> getWeeklyAvailability(
+            Authentication authentication,
+            @PathVariable Long locationId,
+            @RequestParam("week") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate week
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        ManagerWeeklyAvailabilityResponse response =
+                availabilityService.getLocationWeeklyAvailability(actorUserId, locationId, week);
+        return ResponseEntity.ok(response);
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/dto/AvailabilityOverrideResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/dto/AvailabilityOverrideResponse.java
@@ -1,0 +1,12 @@
+package com.shiftsync.shiftsync.availability.dto;
+
+import java.time.LocalDate;
+
+public record AvailabilityOverrideResponse(
+        Long id,
+        LocalDate startDate,
+        LocalDate endDate,
+        String reason
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/dto/CreateAvailabilityOverrideRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/dto/CreateAvailabilityOverrideRequest.java
@@ -1,0 +1,17 @@
+package com.shiftsync.shiftsync.availability.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record CreateAvailabilityOverrideRequest(
+        @NotNull(message = "startDate is required")
+        LocalDate startDate,
+
+        @NotNull(message = "endDate is required")
+        LocalDate endDate,
+
+        String reason
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/dto/ManagerWeeklyAvailabilityResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/dto/ManagerWeeklyAvailabilityResponse.java
@@ -1,0 +1,34 @@
+package com.shiftsync.shiftsync.availability.dto;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record ManagerWeeklyAvailabilityResponse(
+        LocalDate weekStart,
+        LocalDate weekEnd,
+        List<EmployeeWeeklyAvailability> employees
+) {
+
+    public record EmployeeWeeklyAvailability(
+            Long employeeId,
+            String fullName,
+            List<DailyAvailability> days
+    ) {
+    }
+
+    public record DailyAvailability(
+            LocalDate date,
+            DayOfWeek dayOfWeek,
+            boolean overridden,
+            List<TimeWindow> windows
+    ) {
+    }
+
+    public record TimeWindow(
+            LocalTime startTime,
+            LocalTime endTime
+    ) {
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/availability/dto/RecurringAvailabilityItemRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/dto/RecurringAvailabilityItemRequest.java
@@ -1,0 +1,19 @@
+package com.shiftsync.shiftsync.availability.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+public record RecurringAvailabilityItemRequest(
+        @NotNull(message = "dayOfWeek is required")
+        DayOfWeek dayOfWeek,
+
+        @NotNull(message = "startTime is required")
+        LocalTime startTime,
+
+        @NotNull(message = "endTime is required")
+        LocalTime endTime
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/dto/RecurringAvailabilityResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/dto/RecurringAvailabilityResponse.java
@@ -1,0 +1,13 @@
+package com.shiftsync.shiftsync.availability.dto;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+public record RecurringAvailabilityResponse(
+        Long id,
+        DayOfWeek dayOfWeek,
+        LocalTime startTime,
+        LocalTime endTime
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/entity/AvailabilityOverride.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/entity/AvailabilityOverride.java
@@ -1,0 +1,67 @@
+package com.shiftsync.shiftsync.availability.entity;
+
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "availability_overrides")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AvailabilityOverride {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employee_id", nullable = false)
+    private Employee employee;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "reason")
+    private String reason;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/entity/RecurringAvailability.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/entity/RecurringAvailability.java
@@ -1,0 +1,73 @@
+package com.shiftsync.shiftsync.availability.entity;
+
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "recurring_availability")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecurringAvailability {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employee_id", nullable = false)
+    private Employee employee;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "?::day_of_week")
+    @Column(name = "day_of_week", nullable = false)
+    private DayOfWeek dayOfWeek;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/repository/AvailabilityOverrideRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/repository/AvailabilityOverrideRepository.java
@@ -2,6 +2,8 @@ package com.shiftsync.shiftsync.availability.repository;
 
 import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -22,10 +24,17 @@ public interface AvailabilityOverrideRepository extends JpaRepository<Availabili
      * @param startDate  the start date
      * @return the boolean
      */
-    boolean existsByEmployeeIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
-            Long employeeId,
-            LocalDate endDate,
-            LocalDate startDate
+    @Query("""
+            select (count(o) > 0)
+            from AvailabilityOverride o
+            where o.employee.id = :employeeId
+              and o.startDate <= :endDate
+              and o.endDate >= :startDate
+            """)
+    boolean hasOverlap(
+            @Param("employeeId") Long employeeId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
     );
 
     /**
@@ -35,7 +44,35 @@ public interface AvailabilityOverrideRepository extends JpaRepository<Availabili
      * @param date       the date
      * @return the list
      */
-    List<AvailabilityOverride> findByEmployeeIdAndEndDateGreaterThanEqualOrderByStartDateAsc(Long employeeId, LocalDate date);
+    @Query("""
+            select o
+            from AvailabilityOverride o
+            where o.employee.id = :employeeId
+              and o.endDate >= :date
+            order by o.startDate asc
+            """)
+    List<AvailabilityOverride> findActiveByEmployee(@Param("employeeId") Long employeeId, @Param("date") LocalDate date);
+
+    /**
+     * Find by employee id in and start date less than equal and end date greater than equal list.
+     *
+     * @param employeeIds the employee ids
+     * @param endDate     the end date
+     * @param startDate   the start date
+     * @return the list
+     */
+    @Query("""
+            select o
+            from AvailabilityOverride o
+            where o.employee.id in :employeeIds
+              and o.startDate <= :endDate
+              and o.endDate >= :startDate
+            """)
+    List<AvailabilityOverride> findWeekOverlaps(
+            @Param("employeeIds") List<Long> employeeIds,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 
     /**
      * Find by id and employee id optional.

--- a/src/main/java/com/shiftsync/shiftsync/availability/repository/AvailabilityOverrideRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/repository/AvailabilityOverrideRepository.java
@@ -1,0 +1,49 @@
+package com.shiftsync.shiftsync.availability.repository;
+
+import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The interface Availability override repository.
+ */
+@Repository
+public interface AvailabilityOverrideRepository extends JpaRepository<AvailabilityOverride, Long> {
+
+    /**
+     * Exists by employee id and start date less than equal and end date greater than equal boolean.
+     *
+     * @param employeeId the employee id
+     * @param endDate    the end date
+     * @param startDate  the start date
+     * @return the boolean
+     */
+    boolean existsByEmployeeIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
+            Long employeeId,
+            LocalDate endDate,
+            LocalDate startDate
+    );
+
+    /**
+     * Find by employee id and end date greater than equal order by start date asc list.
+     *
+     * @param employeeId the employee id
+     * @param date       the date
+     * @return the list
+     */
+    List<AvailabilityOverride> findByEmployeeIdAndEndDateGreaterThanEqualOrderByStartDateAsc(Long employeeId, LocalDate date);
+
+    /**
+     * Find by id and employee id optional.
+     *
+     * @param id         the id
+     * @param employeeId the employee id
+     * @return the optional
+     */
+    Optional<AvailabilityOverride> findByIdAndEmployeeId(Long id, Long employeeId);
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/repository/RecurringAvailabilityRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/repository/RecurringAvailabilityRepository.java
@@ -1,0 +1,21 @@
+package com.shiftsync.shiftsync.availability.repository;
+
+import com.shiftsync.shiftsync.availability.entity.RecurringAvailability;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The interface Recurring availability repository.
+ */
+@Repository
+public interface RecurringAvailabilityRepository extends JpaRepository<RecurringAvailability, Long> {
+
+
+    /**
+     * Delete by employee id.
+     *
+     * @param employeeId the employee id
+     */
+    void deleteByEmployeeId(Long employeeId);
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/repository/RecurringAvailabilityRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/repository/RecurringAvailabilityRepository.java
@@ -1,8 +1,13 @@
 package com.shiftsync.shiftsync.availability.repository;
 
 import com.shiftsync.shiftsync.availability.entity.RecurringAvailability;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.time.DayOfWeek;
+import java.util.List;
 
 /**
  * The interface Recurring availability repository.
@@ -17,5 +22,19 @@ public interface RecurringAvailabilityRepository extends JpaRepository<Recurring
      * @param employeeId the employee id
      */
     void deleteByEmployeeId(Long employeeId);
+
+    List<RecurringAvailability> findByEmployeeIdIn(List<Long> employeeIds);
+
+    @Query("""
+            select r
+            from RecurringAvailability r
+            where r.employee.id = :employeeId
+              and r.dayOfWeek = :dayOfWeek
+            order by r.startTime asc
+            """)
+    List<RecurringAvailability> findByEmployeeAndDay(
+            @Param("employeeId") Long employeeId,
+            @Param("dayOfWeek") DayOfWeek dayOfWeek
+    );
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/availability/service/AvailabilityService.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/service/AvailabilityService.java
@@ -2,9 +2,11 @@ package com.shiftsync.shiftsync.availability.service;
 
 import com.shiftsync.shiftsync.availability.dto.AvailabilityOverrideResponse;
 import com.shiftsync.shiftsync.availability.dto.CreateAvailabilityOverrideRequest;
+import com.shiftsync.shiftsync.availability.dto.ManagerWeeklyAvailabilityResponse;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityItemRequest;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -48,5 +50,15 @@ public interface AvailabilityService {
      * @param overrideId  the override id
      */
     void deleteOverride(Long actorUserId, Long overrideId);
+
+    /**
+     * Gets location weekly availability.
+     *
+     * @param actorUserId the actor user id
+     * @param locationId  the location id
+     * @param weekDate    the week date
+     * @return the location weekly availability
+     */
+    ManagerWeeklyAvailabilityResponse getLocationWeeklyAvailability(Long actorUserId, Long locationId, LocalDate weekDate);
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/availability/service/AvailabilityService.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/service/AvailabilityService.java
@@ -1,0 +1,25 @@
+package com.shiftsync.shiftsync.availability.service;
+
+import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityItemRequest;
+import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
+
+import java.util.List;
+
+/**
+ * The interface Availability service.
+ */
+public interface AvailabilityService {
+
+    /**
+     * Replace recurring availability list.
+     *
+     * @param actorUserId the actor user id
+     * @param windows     the windows
+     * @return the list
+     */
+    List<RecurringAvailabilityResponse> replaceRecurringAvailability(
+            Long actorUserId,
+            List<RecurringAvailabilityItemRequest> windows
+    );
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/service/AvailabilityService.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/service/AvailabilityService.java
@@ -1,5 +1,7 @@
 package com.shiftsync.shiftsync.availability.service;
 
+import com.shiftsync.shiftsync.availability.dto.AvailabilityOverrideResponse;
+import com.shiftsync.shiftsync.availability.dto.CreateAvailabilityOverrideRequest;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityItemRequest;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
 
@@ -21,5 +23,30 @@ public interface AvailabilityService {
             Long actorUserId,
             List<RecurringAvailabilityItemRequest> windows
     );
+
+    /**
+     * Create override availability override response.
+     *
+     * @param actorUserId the actor user id
+     * @param request     the request
+     * @return the availability override response
+     */
+    AvailabilityOverrideResponse createOverride(Long actorUserId, CreateAvailabilityOverrideRequest request);
+
+    /**
+     * List active overrides list.
+     *
+     * @param actorUserId the actor user id
+     * @return the list
+     */
+    List<AvailabilityOverrideResponse> listActiveOverrides(Long actorUserId);
+
+    /**
+     * Delete override.
+     *
+     * @param actorUserId the actor user id
+     * @param overrideId  the override id
+     */
+    void deleteOverride(Long actorUserId, Long overrideId);
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/availability/service/impl/AvailabilityServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/service/impl/AvailabilityServiceImpl.java
@@ -2,6 +2,7 @@ package com.shiftsync.shiftsync.availability.service.impl;
 
 import com.shiftsync.shiftsync.availability.dto.AvailabilityOverrideResponse;
 import com.shiftsync.shiftsync.availability.dto.CreateAvailabilityOverrideRequest;
+import com.shiftsync.shiftsync.availability.dto.ManagerWeeklyAvailabilityResponse;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityItemRequest;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
 import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
@@ -14,17 +15,22 @@ import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +39,7 @@ public class AvailabilityServiceImpl implements AvailabilityService {
     private final EmployeeRepository employeeRepository;
     private final RecurringAvailabilityRepository recurringAvailabilityRepository;
     private final AvailabilityOverrideRepository availabilityOverrideRepository;
+    private final ManagerLocationRepository managerLocationRepository;
 
     @Override
     @Transactional
@@ -84,11 +91,7 @@ public class AvailabilityServiceImpl implements AvailabilityService {
                 .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
 
         boolean overlaps = availabilityOverrideRepository
-                .existsByEmployeeIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
-                        employee.getId(),
-                        request.endDate(),
-                        request.startDate()
-                );
+                .hasOverlap(employee.getId(), request.startDate(), request.endDate());
 
         if (overlaps) {
             throw new InvalidStateException("Overlapping override dates are not allowed");
@@ -113,7 +116,7 @@ public class AvailabilityServiceImpl implements AvailabilityService {
                 .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
 
         return availabilityOverrideRepository
-                .findByEmployeeIdAndEndDateGreaterThanEqualOrderByStartDateAsc(employee.getId(), LocalDate.now())
+                .findActiveByEmployee(employee.getId(), LocalDate.now())
                 .stream()
                 .map(this::toOverrideResponse)
                 .toList();
@@ -129,6 +132,91 @@ public class AvailabilityServiceImpl implements AvailabilityService {
                 .orElseThrow(() -> new ResourceNotFoundException("Availability override not found"));
 
         availabilityOverrideRepository.delete(override);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ManagerWeeklyAvailabilityResponse getLocationWeeklyAvailability(Long actorUserId, Long locationId, LocalDate weekDate) {
+        if (weekDate == null) {
+            throw new BadRequestException("week is required");
+        }
+
+        Employee manager = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
+
+        List<Long> assignedLocationIds = managerLocationRepository.findLocationIdsByManagerEmployeeId(manager.getId());
+        if (!assignedLocationIds.contains(locationId)) {
+            throw new AccessDeniedException("You are not assigned to this location");
+        }
+
+        LocalDate weekStart = weekDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate weekEnd = weekStart.plusDays(6);
+
+        List<Employee> employees = employeeRepository.findByLocationIdAndActiveTrueWithUser(locationId);
+        if (employees.isEmpty()) {
+            return new ManagerWeeklyAvailabilityResponse(weekStart, weekEnd, List.of());
+        }
+
+        List<Long> employeeIds = employees.stream().map(Employee::getId).toList();
+
+        Map<EmployeeDayKey, List<ManagerWeeklyAvailabilityResponse.TimeWindow>> recurringByEmployeeDay =
+                recurringAvailabilityRepository.findByEmployeeIdIn(employeeIds).stream()
+                        .collect(Collectors.groupingBy(
+                                recurring -> new EmployeeDayKey(recurring.getEmployee().getId(), recurring.getDayOfWeek()),
+                                Collectors.mapping(
+                                        recurring -> new ManagerWeeklyAvailabilityResponse.TimeWindow(
+                                                recurring.getStartTime(),
+                                                recurring.getEndTime()
+                                        ),
+                                        Collectors.collectingAndThen(Collectors.toList(), list -> list.stream()
+                                                .sorted(Comparator.comparing(ManagerWeeklyAvailabilityResponse.TimeWindow::startTime))
+                                                .toList())
+                                )
+                        ));
+
+        Map<Long, Set<LocalDate>> blockedDatesByEmployee = availabilityOverrideRepository
+                .findWeekOverlaps(employeeIds, weekStart, weekEnd)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        override -> override.getEmployee().getId(),
+                        Collectors.flatMapping(
+                                override -> override.getStartDate().datesUntil(override.getEndDate().plusDays(1)),
+                                Collectors.toSet()
+                        )
+                ));
+
+        List<ManagerWeeklyAvailabilityResponse.EmployeeWeeklyAvailability> employeeAvailability = employees.stream()
+                .map(employee -> {
+                    List<ManagerWeeklyAvailabilityResponse.DailyAvailability> dailyAvailability = new ArrayList<>();
+
+                    for (int i = 0; i < 7; i++) {
+                        LocalDate date = weekStart.plusDays(i);
+                        DayOfWeek day = date.getDayOfWeek();
+                        boolean overridden = blockedDatesByEmployee
+                                .getOrDefault(employee.getId(), Set.of())
+                                .contains(date);
+
+                        List<ManagerWeeklyAvailabilityResponse.TimeWindow> windows = overridden
+                                ? List.of()
+                                : recurringByEmployeeDay.getOrDefault(new EmployeeDayKey(employee.getId(), day), List.of());
+
+                        dailyAvailability.add(new ManagerWeeklyAvailabilityResponse.DailyAvailability(
+                                date,
+                                day,
+                                overridden,
+                                windows
+                        ));
+                    }
+
+                    return new ManagerWeeklyAvailabilityResponse.EmployeeWeeklyAvailability(
+                            employee.getId(),
+                            employee.getUser().getFullName(),
+                            dailyAvailability
+                    );
+                })
+                .toList();
+
+        return new ManagerWeeklyAvailabilityResponse(weekStart, weekEnd, employeeAvailability);
     }
 
     private void validateTimeOrder(List<RecurringAvailabilityItemRequest> windows) {
@@ -186,6 +274,9 @@ public class AvailabilityServiceImpl implements AvailabilityService {
         if (endDate.isBefore(startDate)) {
             throw new BadRequestException("endDate must be on or after startDate");
         }
+    }
+
+    private record EmployeeDayKey(Long employeeId, DayOfWeek dayOfWeek) {
     }
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/availability/service/impl/AvailabilityServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/service/impl/AvailabilityServiceImpl.java
@@ -1,11 +1,16 @@
 package com.shiftsync.shiftsync.availability.service.impl;
 
+import com.shiftsync.shiftsync.availability.dto.AvailabilityOverrideResponse;
+import com.shiftsync.shiftsync.availability.dto.CreateAvailabilityOverrideRequest;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityItemRequest;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
+import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
 import com.shiftsync.shiftsync.availability.entity.RecurringAvailability;
+import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepository;
 import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepository;
 import com.shiftsync.shiftsync.availability.service.AvailabilityService;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
@@ -14,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -26,6 +32,7 @@ public class AvailabilityServiceImpl implements AvailabilityService {
 
     private final EmployeeRepository employeeRepository;
     private final RecurringAvailabilityRepository recurringAvailabilityRepository;
+    private final AvailabilityOverrideRepository availabilityOverrideRepository;
 
     @Override
     @Transactional
@@ -68,6 +75,62 @@ public class AvailabilityServiceImpl implements AvailabilityService {
                 .toList();
     }
 
+    @Override
+    @Transactional
+    public AvailabilityOverrideResponse createOverride(Long actorUserId, CreateAvailabilityOverrideRequest request) {
+        validateDateOrder(request.startDate(), request.endDate());
+
+        Employee employee = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
+
+        boolean overlaps = availabilityOverrideRepository
+                .existsByEmployeeIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
+                        employee.getId(),
+                        request.endDate(),
+                        request.startDate()
+                );
+
+        if (overlaps) {
+            throw new InvalidStateException("Overlapping override dates are not allowed");
+        }
+
+        AvailabilityOverride saved = availabilityOverrideRepository.save(
+                AvailabilityOverride.builder()
+                        .employee(employee)
+                        .startDate(request.startDate())
+                        .endDate(request.endDate())
+                        .reason(request.reason())
+                        .build()
+        );
+
+        return toOverrideResponse(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AvailabilityOverrideResponse> listActiveOverrides(Long actorUserId) {
+        Employee employee = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
+
+        return availabilityOverrideRepository
+                .findByEmployeeIdAndEndDateGreaterThanEqualOrderByStartDateAsc(employee.getId(), LocalDate.now())
+                .stream()
+                .map(this::toOverrideResponse)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public void deleteOverride(Long actorUserId, Long overrideId) {
+        Employee employee = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
+
+        AvailabilityOverride override = availabilityOverrideRepository.findByIdAndEmployeeId(overrideId, employee.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Availability override not found"));
+
+        availabilityOverrideRepository.delete(override);
+    }
+
     private void validateTimeOrder(List<RecurringAvailabilityItemRequest> windows) {
         windows.forEach(item -> {
             if (!item.endTime().isAfter(item.startTime())) {
@@ -104,6 +167,25 @@ public class AvailabilityServiceImpl implements AvailabilityService {
                 availability.getStartTime(),
                 availability.getEndTime()
         );
+    }
+
+    private AvailabilityOverrideResponse toOverrideResponse(AvailabilityOverride override) {
+        return new AvailabilityOverrideResponse(
+                override.getId(),
+                override.getStartDate(),
+                override.getEndDate(),
+                override.getReason()
+        );
+    }
+
+    private void validateDateOrder(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) {
+            throw new BadRequestException("startDate and endDate are required");
+        }
+
+        if (endDate.isBefore(startDate)) {
+            throw new BadRequestException("endDate must be on or after startDate");
+        }
     }
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/availability/service/impl/AvailabilityServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/service/impl/AvailabilityServiceImpl.java
@@ -1,0 +1,110 @@
+package com.shiftsync.shiftsync.availability.service.impl;
+
+import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityItemRequest;
+import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
+import com.shiftsync.shiftsync.availability.entity.RecurringAvailability;
+import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepository;
+import com.shiftsync.shiftsync.availability.service.AvailabilityService;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AvailabilityServiceImpl implements AvailabilityService {
+
+    private final EmployeeRepository employeeRepository;
+    private final RecurringAvailabilityRepository recurringAvailabilityRepository;
+
+    @Override
+    @Transactional
+    public List<RecurringAvailabilityResponse> replaceRecurringAvailability(
+            Long actorUserId,
+            List<RecurringAvailabilityItemRequest> windows
+    ) {
+        if (windows == null) {
+            throw new BadRequestException("Recurring availability payload is required");
+        }
+
+        validateTimeOrder(windows);
+        validateNoSameDayOverlaps(windows);
+
+        Employee employee = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
+
+        recurringAvailabilityRepository.deleteByEmployeeId(employee.getId());
+
+        if (windows.isEmpty()) {
+            return List.of();
+        }
+
+        List<RecurringAvailability> entities = windows.stream()
+                .map(item -> RecurringAvailability.builder()
+                        .employee(employee)
+                        .dayOfWeek(item.dayOfWeek())
+                        .startTime(item.startTime())
+                        .endTime(item.endTime())
+                        .build())
+                .toList();
+
+        List<RecurringAvailability> saved = recurringAvailabilityRepository.saveAll(entities);
+
+        return saved.stream()
+                .sorted(Comparator
+                        .comparing(RecurringAvailability::getDayOfWeek)
+                        .thenComparing(RecurringAvailability::getStartTime))
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private void validateTimeOrder(List<RecurringAvailabilityItemRequest> windows) {
+        windows.forEach(item -> {
+            if (!item.endTime().isAfter(item.startTime())) {
+                throw new BadRequestException("endTime must be after startTime for " + item.dayOfWeek());
+            }
+        });
+    }
+
+    private void validateNoSameDayOverlaps(List<RecurringAvailabilityItemRequest> windows) {
+        Map<DayOfWeek, List<RecurringAvailabilityItemRequest>> groupedByDay = new HashMap<>();
+
+        for (RecurringAvailabilityItemRequest window : windows) {
+            groupedByDay.computeIfAbsent(window.dayOfWeek(), ignored -> new ArrayList<>()).add(window);
+        }
+
+        groupedByDay.forEach((day, dayWindows) -> {
+            dayWindows.sort(Comparator.comparing(RecurringAvailabilityItemRequest::startTime));
+
+            for (int i = 1; i < dayWindows.size(); i++) {
+                RecurringAvailabilityItemRequest previous = dayWindows.get(i - 1);
+                RecurringAvailabilityItemRequest current = dayWindows.get(i);
+
+                if (current.startTime().isBefore(previous.endTime())) {
+                    throw new BadRequestException("Overlapping recurring availability windows are not allowed for " + day);
+                }
+            }
+        });
+    }
+
+    private RecurringAvailabilityResponse toResponse(RecurringAvailability availability) {
+        return new RecurringAvailabilityResponse(
+                availability.getId(),
+                availability.getDayOfWeek(),
+                availability.getStartTime(),
+                availability.getEndTime()
+        );
+    }
+}
+
+

--- a/src/main/java/com/shiftsync/shiftsync/common/exception/BadRequestException.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package com.shiftsync.shiftsync.common.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/exception/GlobalExceptionHandler.java
@@ -99,6 +99,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
 
+    @ExceptionHandler(UnprocessableEntityException.class)
+    public ResponseEntity<ErrorResponse> handleUnprocessableEntity(UnprocessableEntityException ex) {
+        log.warn("Unprocessable entity: {}", ex.getMessage());
+        ErrorResponse response = new ErrorResponse(
+                422,
+                "Unprocessable Entity",
+                ex.getMessage()
+        );
+        return ResponseEntity.status(422).body(response);
+    }
+
     @ExceptionHandler({BadCredentialsException.class, AuthenticationException.class})
     public ResponseEntity<ErrorResponse> handleAuthenticationException(Exception ex) {
         log.warn("Authentication failed: {}", ex.getMessage());

--- a/src/main/java/com/shiftsync/shiftsync/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/exception/GlobalExceptionHandler.java
@@ -77,6 +77,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
 
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequest(BadRequestException ex) {
+        log.warn("Bad request: {}", ex.getMessage());
+        ErrorResponse response = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad Request",
+                ex.getMessage()
+        );
+        return ResponseEntity.badRequest().body(response);
+    }
+
     @ExceptionHandler(InvalidStateException.class)
     public ResponseEntity<ErrorResponse> handleInvalidState(InvalidStateException ex) {
         log.warn("Invalid resource state: {}", ex.getMessage());

--- a/src/main/java/com/shiftsync/shiftsync/common/exception/UnprocessableEntityException.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/exception/UnprocessableEntityException.java
@@ -1,0 +1,9 @@
+package com.shiftsync.shiftsync.common.exception;
+
+public class UnprocessableEntityException extends RuntimeException {
+
+    public UnprocessableEntityException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/employee/repository/EmployeeRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/employee/repository/EmployeeRepository.java
@@ -3,8 +3,10 @@ package com.shiftsync.shiftsync.employee.repository;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -28,5 +30,8 @@ public interface EmployeeRepository extends JpaRepository<Employee, Long>, JpaSp
      * @return the optional
      */
     Optional<Employee> findByUserId(Long userId);
+
+    @Query("select e from Employee e join fetch e.user where e.location.id = :locationId and e.active = true")
+    List<Employee> findByLocationIdAndActiveTrueWithUser(Long locationId);
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftAssignmentController.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftAssignmentController.java
@@ -1,0 +1,66 @@
+package com.shiftsync.shiftsync.shift.controller;
+
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.shift.dto.AssignEmployeeRequest;
+import com.shiftsync.shiftsync.shift.dto.AssignEmployeeResponse;
+import com.shiftsync.shiftsync.shift.service.ShiftAssignmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/shifts")
+@RequiredArgsConstructor
+@Tag(name = "Shift Assignments", description = "Shift assignment endpoints")
+public class ShiftAssignmentController {
+
+    private final ShiftAssignmentService shiftAssignmentService;
+    private final AuthenticationHelper authenticationHelper;
+
+    @PostMapping("/{shiftId}/assignments")
+    @PreAuthorize("hasRole('MANAGER')")
+    @Operation(
+            summary = "Assign employee to shift",
+            description = "Returns WARNING for availability mismatch unless override=true is provided."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Warning returned for availability mismatch", content = @Content(schema = @Schema(implementation = AssignEmployeeResponse.class))),
+            @ApiResponse(responseCode = "201", description = "Assignment created", content = @Content(schema = @Schema(implementation = AssignEmployeeResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Shift or employee not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Invalid state (duplicate assignment or cancelled shift)", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<AssignEmployeeResponse> assignEmployee(
+            Authentication authentication,
+            @PathVariable Long shiftId,
+            @Valid @RequestBody AssignEmployeeRequest request,
+            @RequestParam(defaultValue = "false") boolean override
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        AssignEmployeeResponse response = shiftAssignmentService.assignEmployee(actorUserId, shiftId, request, override);
+
+        if ("WARNING".equals(response.status())) {
+            return ResponseEntity.ok(response);
+        }
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/AssignEmployeeRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/AssignEmployeeRequest.java
@@ -1,0 +1,10 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AssignEmployeeRequest(
+        @NotNull(message = "employeeId is required")
+        Long employeeId
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/AssignEmployeeResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/AssignEmployeeResponse.java
@@ -1,0 +1,12 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+import java.util.List;
+
+public record AssignEmployeeResponse(
+        String status,
+        List<String> conflicts,
+        String message,
+        Long assignmentId
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/shift/entity/Shift.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/entity/Shift.java
@@ -1,0 +1,98 @@
+package com.shiftsync.shiftsync.shift.entity;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.department.entity.Department;
+import com.shiftsync.shiftsync.location.entity.Location;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "shifts")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Shift {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", nullable = false)
+    private Location location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id", nullable = false)
+    private Department department;
+
+    @Column(name = "shift_date", nullable = false)
+    private LocalDate shiftDate;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "required_skill")
+    private String requiredSkill;
+
+    @Column(name = "minimum_headcount", nullable = false)
+    private Integer minimumHeadcount;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "?::shift_status")
+    @Column(name = "status", nullable = false)
+    private ShiftStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (status == null) {
+            status = ShiftStatus.OPEN;
+        }
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/shift/entity/ShiftAssignment.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/entity/ShiftAssignment.java
@@ -1,0 +1,82 @@
+package com.shiftsync.shiftsync.shift.entity;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "shift_assignments")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ShiftAssignment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shift_id", nullable = false)
+    private Shift shift;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employee_id", nullable = false)
+    private Employee employee;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assigned_by", nullable = false)
+    private User assignedBy;
+
+    @Column(name = "override_applied", nullable = false)
+    private Boolean overrideApplied;
+
+    @Column(name = "override_reason")
+    private String overrideReason;
+
+    @Column(name = "assigned_at", nullable = false)
+    private LocalDateTime assignedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (overrideApplied == null) {
+            overrideApplied = false;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        if (assignedAt == null) {
+            assignedAt = now;
+        }
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/shift/entity/ShiftStatus.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/entity/ShiftStatus.java
@@ -1,0 +1,7 @@
+package com.shiftsync.shiftsync.shift.entity;
+
+public enum ShiftStatus {
+    OPEN,
+    CANCELLED
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
@@ -1,0 +1,22 @@
+package com.shiftsync.shiftsync.shift.repository;
+
+import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The interface Shift assignment repository.
+ */
+@Repository
+public interface ShiftAssignmentRepository extends JpaRepository<ShiftAssignment, Long> {
+
+    /**
+     * Exists by shift id and employee id boolean.
+     *
+     * @param shiftId    the shift id
+     * @param employeeId the employee id
+     * @return the boolean
+     */
+    boolean existsByShiftIdAndEmployeeId(Long shiftId, Long employeeId);
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftRepository.java
@@ -1,0 +1,13 @@
+package com.shiftsync.shiftsync.shift.repository;
+
+import com.shiftsync.shiftsync.shift.entity.Shift;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The interface Shift repository.
+ */
+@Repository
+public interface ShiftRepository extends JpaRepository<Shift, Long> {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentService.java
@@ -1,0 +1,22 @@
+package com.shiftsync.shiftsync.shift.service;
+
+import com.shiftsync.shiftsync.shift.dto.AssignEmployeeRequest;
+import com.shiftsync.shiftsync.shift.dto.AssignEmployeeResponse;
+
+/**
+ * The interface Shift assignment service.
+ */
+public interface ShiftAssignmentService {
+
+    /**
+     * Assign employee assign employee response.
+     *
+     * @param actorUserId the actor user id
+     * @param shiftId     the shift id
+     * @param request     the request
+     * @param override    the override
+     * @return the assign employee response
+     */
+    AssignEmployeeResponse assignEmployee(Long actorUserId, Long shiftId, AssignEmployeeRequest request, boolean override);
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
@@ -1,0 +1,122 @@
+package com.shiftsync.shiftsync.shift.service.impl;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.auth.repository.UserRepository;
+import com.shiftsync.shiftsync.availability.entity.RecurringAvailability;
+import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepository;
+import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepository;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
+import com.shiftsync.shiftsync.shift.dto.AssignEmployeeRequest;
+import com.shiftsync.shiftsync.shift.dto.AssignEmployeeResponse;
+import com.shiftsync.shiftsync.shift.entity.Shift;
+import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
+import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
+import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
+import com.shiftsync.shiftsync.shift.repository.ShiftRepository;
+import com.shiftsync.shiftsync.shift.service.ShiftAssignmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
+
+    private static final String AVAILABILITY_MISMATCH = "AVAILABILITY_MISMATCH";
+
+    private final EmployeeRepository employeeRepository;
+    private final UserRepository userRepository;
+    private final ShiftRepository shiftRepository;
+    private final ShiftAssignmentRepository shiftAssignmentRepository;
+    private final ManagerLocationRepository managerLocationRepository;
+    private final RecurringAvailabilityRepository recurringAvailabilityRepository;
+    private final AvailabilityOverrideRepository availabilityOverrideRepository;
+
+    @Override
+    @Transactional
+    public AssignEmployeeResponse assignEmployee(Long actorUserId, Long shiftId, AssignEmployeeRequest request, boolean override) {
+        Employee manager = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
+
+        Shift shift = shiftRepository.findById(shiftId)
+                .orElseThrow(() -> new ResourceNotFoundException("Shift not found"));
+
+        if (shift.getStatus() == ShiftStatus.CANCELLED) {
+            throw new InvalidStateException("Cannot assign employees to a cancelled shift");
+        }
+
+        List<Long> assignedLocations = managerLocationRepository.findLocationIdsByManagerEmployeeId(manager.getId());
+        if (!assignedLocations.contains(shift.getLocation().getId())) {
+            throw new AccessDeniedException("You are not assigned to this location");
+        }
+
+        Employee employee = employeeRepository.findById(request.employeeId())
+                .orElseThrow(() -> new ResourceNotFoundException("Employee not found"));
+
+        if (shiftAssignmentRepository.existsByShiftIdAndEmployeeId(shiftId, employee.getId())) {
+            throw new InvalidStateException("Employee is already assigned to this shift");
+        }
+
+        boolean availabilityMismatch = isAvailabilityMismatch(employee.getId(), shift);
+        if (availabilityMismatch && !override) {
+            return new AssignEmployeeResponse(
+                    "WARNING",
+                    List.of(AVAILABILITY_MISMATCH),
+                    "Employee availability does not match this shift. Re-submit with override=true to proceed.",
+                    null
+            );
+        }
+
+        User assignedBy = userRepository.findById(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        ShiftAssignment assignment = ShiftAssignment.builder()
+                .shift(shift)
+                .employee(employee)
+                .assignedBy(assignedBy)
+                .overrideApplied(availabilityMismatch)
+                .overrideReason(availabilityMismatch ? AVAILABILITY_MISMATCH : null)
+                .build();
+
+        ShiftAssignment saved = shiftAssignmentRepository.save(assignment);
+
+        return new AssignEmployeeResponse(
+                "ASSIGNED",
+                List.of(),
+                "Employee assigned successfully",
+                saved.getId()
+        );
+    }
+
+    private boolean isAvailabilityMismatch(Long employeeId, Shift shift) {
+        boolean hasOverrideOnDate = availabilityOverrideRepository.hasOverlap(
+                employeeId,
+                shift.getShiftDate(),
+                shift.getShiftDate()
+        );
+
+        if (hasOverrideOnDate) {
+            return true;
+        }
+
+        List<RecurringAvailability> dayWindows = recurringAvailabilityRepository
+                .findByEmployeeAndDay(employeeId, shift.getShiftDate().getDayOfWeek());
+
+        if (dayWindows.isEmpty()) {
+            return true;
+        }
+
+        return dayWindows.stream().noneMatch(window ->
+                !shift.getStartTime().isBefore(window.getStartTime())
+                        && !shift.getEndTime().isAfter(window.getEndTime())
+        );
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
@@ -7,6 +7,7 @@ import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepos
 import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepository;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.common.exception.UnprocessableEntityException;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
@@ -60,11 +61,20 @@ public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
         Employee employee = employeeRepository.findById(request.employeeId())
                 .orElseThrow(() -> new ResourceNotFoundException("Employee not found"));
 
+        if (!Boolean.TRUE.equals(employee.getActive())) {
+            throw new UnprocessableEntityException("Cannot assign an inactive employee to a shift");
+        }
+
         if (shiftAssignmentRepository.existsByShiftIdAndEmployeeId(shiftId, employee.getId())) {
             throw new InvalidStateException("Employee is already assigned to this shift");
         }
 
+        // TODO (Week 3 - FR-CONFLICT-01): reject if employee already assigned to an overlapping shift -> 409
+        // TODO (Week 3 - FR-CONFLICT-02): reject if shift falls within an approved leave period -> 409
+
         boolean availabilityMismatch = isAvailabilityMismatch(employee.getId(), shift);
+
+        // TODO (Week 3 - FR-CONFLICT-04): add overtime threshold warning to conflicts list
         if (availabilityMismatch && !override) {
             return new AssignEmployeeResponse(
                     "WARNING",

--- a/src/main/resources/db/changelog/changes/004-add-availability-and-shift-tables.xml
+++ b/src/main/resources/db/changelog/changes/004-add-availability-and-shift-tables.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <changeSet id="004-001-ensure-availability-enums" author="shiftsync">
+        <sql>
+            DO $$ BEGIN
+                CREATE TYPE day_of_week AS ENUM (
+                    'MONDAY',
+                    'TUESDAY',
+                    'WEDNESDAY',
+                    'THURSDAY',
+                    'FRIDAY',
+                    'SATURDAY',
+                    'SUNDAY'
+                );
+            EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+            DO $$ BEGIN
+                CREATE TYPE shift_status AS ENUM ('OPEN', 'CANCELLED');
+            EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+        </sql>
+    </changeSet>
+
+    <changeSet id="004-002-create-recurring-availability-table" author="shiftsync">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="recurring_availability"/>
+            </not>
+        </preConditions>
+        <createTable tableName="recurring_availability">
+            <column name="id" type="bigserial">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="employee_id" type="bigint">
+                <constraints nullable="false" foreignKeyName="fk_recurring_availability_employee"
+                             references="employees(id)" deleteCascade="true"/>
+            </column>
+            <column name="day_of_week" type="day_of_week">
+                <constraints nullable="false"/>
+            </column>
+            <column name="start_time" type="time">
+                <constraints nullable="false"/>
+            </column>
+            <column name="end_time" type="time">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <sql>
+            ALTER TABLE recurring_availability ADD CONSTRAINT check_time_order CHECK (end_time > start_time);
+        </sql>
+        <createIndex tableName="recurring_availability" indexName="idx_recurring_availability_employee">
+            <column name="employee_id"/>
+        </createIndex>
+        <createIndex tableName="recurring_availability" indexName="idx_recurring_availability_day">
+            <column name="day_of_week"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="004-003-create-availability-overrides-table" author="shiftsync">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="availability_overrides"/>
+            </not>
+        </preConditions>
+        <createTable tableName="availability_overrides">
+            <column name="id" type="bigserial">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="employee_id" type="bigint">
+                <constraints nullable="false" foreignKeyName="fk_availability_overrides_employee"
+                             references="employees(id)" deleteCascade="true"/>
+            </column>
+            <column name="start_date" type="date">
+                <constraints nullable="false"/>
+            </column>
+            <column name="end_date" type="date">
+                <constraints nullable="false"/>
+            </column>
+            <column name="reason" type="text"/>
+            <column name="created_at" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <sql>
+            ALTER TABLE availability_overrides ADD CONSTRAINT check_date_order CHECK (end_date >= start_date);
+        </sql>
+        <createIndex tableName="availability_overrides" indexName="idx_availability_overrides_employee">
+            <column name="employee_id"/>
+        </createIndex>
+        <createIndex tableName="availability_overrides" indexName="idx_availability_overrides_dates">
+            <column name="start_date"/>
+            <column name="end_date"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="004-004-create-shifts-table" author="shiftsync">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="shifts"/>
+            </not>
+        </preConditions>
+        <createTable tableName="shifts">
+            <column name="id" type="bigserial">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="location_id" type="bigint">
+                <constraints nullable="false" foreignKeyName="fk_shifts_location"
+                             references="locations(id)" deleteCascade="true"/>
+            </column>
+            <column name="department_id" type="bigint">
+                <constraints nullable="false" foreignKeyName="fk_shifts_department"
+                             references="departments(id)" deleteCascade="true"/>
+            </column>
+            <column name="shift_date" type="date">
+                <constraints nullable="false"/>
+            </column>
+            <column name="start_time" type="time">
+                <constraints nullable="false"/>
+            </column>
+            <column name="end_time" type="time">
+                <constraints nullable="false"/>
+            </column>
+            <column name="required_skill" type="varchar(255)"/>
+            <column name="minimum_headcount" type="integer" defaultValue="1">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="shift_status" defaultValue="OPEN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="bigint">
+                <constraints nullable="false" foreignKeyName="fk_shifts_created_by" references="users(id)"/>
+            </column>
+            <column name="cancelled_at" type="timestamp"/>
+            <column name="created_at" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <sql>
+            ALTER TABLE shifts ADD CONSTRAINT check_shift_time_order CHECK (end_time > start_time);
+        </sql>
+        <createIndex tableName="shifts" indexName="idx_shifts_location">
+            <column name="location_id"/>
+        </createIndex>
+        <createIndex tableName="shifts" indexName="idx_shifts_department">
+            <column name="department_id"/>
+        </createIndex>
+        <createIndex tableName="shifts" indexName="idx_shifts_date">
+            <column name="shift_date"/>
+        </createIndex>
+        <createIndex tableName="shifts" indexName="idx_shifts_status">
+            <column name="status"/>
+        </createIndex>
+        <createIndex tableName="shifts" indexName="idx_shifts_location_date">
+            <column name="location_id"/>
+            <column name="shift_date"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="004-005-create-shift-assignments-table" author="shiftsync">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="shift_assignments"/>
+            </not>
+        </preConditions>
+        <createTable tableName="shift_assignments">
+            <column name="id" type="bigserial">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="shift_id" type="bigint">
+                <constraints nullable="false" foreignKeyName="fk_shift_assignments_shift"
+                             references="shifts(id)" deleteCascade="true"/>
+            </column>
+            <column name="employee_id" type="bigint">
+                <constraints nullable="false" foreignKeyName="fk_shift_assignments_employee"
+                             references="employees(id)" deleteCascade="true"/>
+            </column>
+            <column name="assigned_by" type="bigint">
+                <constraints nullable="false" foreignKeyName="fk_shift_assignments_assigned_by"
+                             references="users(id)"/>
+            </column>
+            <column name="override_applied" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="override_reason" type="text"/>
+            <column name="assigned_at" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="timestamp" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint tableName="shift_assignments" columnNames="shift_id, employee_id"
+                             constraintName="uk_shift_assignments"/>
+        <createIndex tableName="shift_assignments" indexName="idx_shift_assignments_shift">
+            <column name="shift_id"/>
+        </createIndex>
+        <createIndex tableName="shift_assignments" indexName="idx_shift_assignments_employee">
+            <column name="employee_id"/>
+        </createIndex>
+        <createIndex tableName="shift_assignments" indexName="idx_shift_assignments_assigned_at">
+            <column name="assigned_at"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>
+

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -9,5 +9,6 @@
     <include file="db/changelog/changes/001-initial-schema.xml"/>
     <include file="db/changelog/changes/002-add-employees-notification-enabled.xml"/>
     <include file="db/changelog/changes/003-add-users-must-reset-password.xml"/>
+    <include file="db/changelog/changes/004-add-availability-and-shift-tables.xml"/>
 
 </databaseChangeLog>

--- a/src/test/java/com/shiftsync/shiftsync/availability/controller/AvailabilityControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/availability/controller/AvailabilityControllerWebMvcTest.java
@@ -1,8 +1,10 @@
 package com.shiftsync.shiftsync.availability.controller;
 
+import com.shiftsync.shiftsync.availability.dto.AvailabilityOverrideResponse;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
 import com.shiftsync.shiftsync.availability.service.AvailabilityService;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
 import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
@@ -19,13 +21,19 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -112,6 +120,87 @@ class AvailabilityControllerWebMvcTest {
         mockMvc.perform(put("/api/v1/employees/me/availability/recurring")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("[]"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void createOverride_Success_ReturnsCreated() throws Exception {
+        when(availabilityService.createOverride(anyLong(), any())).thenReturn(
+                new AvailabilityOverrideResponse(10L, LocalDate.of(2026, 4, 10), LocalDate.of(2026, 4, 12), "Travel")
+        );
+
+        String body = """
+                {
+                  "startDate": "2026-04-10",
+                  "endDate": "2026-04-12",
+                  "reason": "Travel"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/employees/me/availability/overrides")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", org.hamcrest.Matchers.containsString("/api/v1/employees/me/availability/overrides/10")))
+                .andExpect(jsonPath("$.id").value(10));
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void createOverride_Overlap_ReturnsConflict() throws Exception {
+        when(availabilityService.createOverride(anyLong(), any()))
+                .thenThrow(new InvalidStateException("Overlapping override dates are not allowed"));
+
+        String body = """
+                {
+                  "startDate": "2026-04-10",
+                  "endDate": "2026-04-12",
+                  "reason": "Travel"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/employees/me/availability/overrides")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Overlapping override dates are not allowed"));
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void listOverrides_ReturnsOk() throws Exception {
+        when(availabilityService.listActiveOverrides(anyLong())).thenReturn(List.of(
+                new AvailabilityOverrideResponse(10L, LocalDate.of(2026, 4, 10), LocalDate.of(2026, 4, 12), "Travel")
+        ));
+
+        mockMvc.perform(get("/api/v1/employees/me/availability/overrides"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].reason").value("Travel"));
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void deleteOverride_ReturnsNoContent() throws Exception {
+        doNothing().when(availabilityService).deleteOverride(5L, 10L);
+
+        mockMvc.perform(delete("/api/v1/employees/me/availability/overrides/10"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "MANAGER")
+    void createOverride_WrongRole_ReturnsForbidden() throws Exception {
+        String body = """
+                {
+                  "startDate": "2026-04-10",
+                  "endDate": "2026-04-12"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/employees/me/availability/overrides")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
                 .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/com/shiftsync/shiftsync/availability/controller/AvailabilityControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/availability/controller/AvailabilityControllerWebMvcTest.java
@@ -1,0 +1,118 @@
+package com.shiftsync.shiftsync.availability.controller;
+
+import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
+import com.shiftsync.shiftsync.availability.service.AvailabilityService;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AvailabilityController.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, AuthenticationHelper.class})
+class AvailabilityControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AvailabilityService availabilityService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Test
+    void replaceRecurringAvailability_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(put("/api/v1/employees/me/availability/recurring")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[]"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void replaceRecurringAvailability_Success_ReturnsOk() throws Exception {
+        when(availabilityService.replaceRecurringAvailability(anyLong(), any())).thenReturn(List.of(
+                new RecurringAvailabilityResponse(1L, DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(13, 0))
+        ));
+
+        String body = """
+                [
+                  {
+                    "dayOfWeek": "MONDAY",
+                    "startTime": "09:00:00",
+                    "endTime": "13:00:00"
+                  }
+                ]
+                """;
+
+        mockMvc.perform(put("/api/v1/employees/me/availability/recurring")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].dayOfWeek").value("MONDAY"));
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void replaceRecurringAvailability_Overlap_ReturnsBadRequest() throws Exception {
+        when(availabilityService.replaceRecurringAvailability(anyLong(), any()))
+                .thenThrow(new BadRequestException("Overlapping recurring availability windows are not allowed for MONDAY"));
+
+        String body = """
+                [
+                  {
+                    "dayOfWeek": "MONDAY",
+                    "startTime": "09:00:00",
+                    "endTime": "13:00:00"
+                  },
+                  {
+                    "dayOfWeek": "MONDAY",
+                    "startTime": "12:00:00",
+                    "endTime": "16:00:00"
+                  }
+                ]
+                """;
+
+        mockMvc.perform(put("/api/v1/employees/me/availability/recurring")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Overlapping recurring availability windows are not allowed for MONDAY"));
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "MANAGER")
+    void replaceRecurringAvailability_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(put("/api/v1/employees/me/availability/recurring")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[]"))
+                .andExpect(status().isForbidden());
+    }
+}
+

--- a/src/test/java/com/shiftsync/shiftsync/availability/controller/ManagerAvailabilityControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/availability/controller/ManagerAvailabilityControllerWebMvcTest.java
@@ -1,0 +1,97 @@
+package com.shiftsync.shiftsync.availability.controller;
+
+import com.shiftsync.shiftsync.availability.dto.ManagerWeeklyAvailabilityResponse;
+import com.shiftsync.shiftsync.availability.service.AvailabilityService;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ManagerAvailabilityController.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, AuthenticationHelper.class})
+class ManagerAvailabilityControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AvailabilityService availabilityService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Test
+    void getWeeklyAvailability_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/locations/1/availability")
+                        .param("week", "2026-04-08"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "MANAGER")
+    void getWeeklyAvailability_Success_ReturnsOk() throws Exception {
+        ManagerWeeklyAvailabilityResponse.TimeWindow window =
+                new ManagerWeeklyAvailabilityResponse.TimeWindow(LocalTime.of(9, 0), LocalTime.of(13, 0));
+
+        ManagerWeeklyAvailabilityResponse.DailyAvailability day =
+                new ManagerWeeklyAvailabilityResponse.DailyAvailability(
+                        LocalDate.of(2026, 4, 7),
+                        DayOfWeek.TUESDAY,
+                        false,
+                        List.of(window)
+                );
+
+        ManagerWeeklyAvailabilityResponse.EmployeeWeeklyAvailability employee =
+                new ManagerWeeklyAvailabilityResponse.EmployeeWeeklyAvailability(20L, "Employee Two", List.of(day));
+
+        ManagerWeeklyAvailabilityResponse response = new ManagerWeeklyAvailabilityResponse(
+                LocalDate.of(2026, 4, 6),
+                LocalDate.of(2026, 4, 12),
+                List.of(employee)
+        );
+
+        when(availabilityService.getLocationWeeklyAvailability(anyLong(), eq(1L), eq(LocalDate.of(2026, 4, 8))))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/api/v1/locations/1/availability")
+                        .param("week", "2026-04-08"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.weekStart").value("2026-04-06"))
+                .andExpect(jsonPath("$.employees[0].employeeId").value(20))
+                .andExpect(jsonPath("$.employees[0].days[0].windows[0].startTime").value("09:00:00"));
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void getWeeklyAvailability_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/locations/1/availability")
+                        .param("week", "2026-04-08"))
+                .andExpect(status().isForbidden());
+    }
+}
+

--- a/src/test/java/com/shiftsync/shiftsync/availability/service/AvailabilityServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/availability/service/AvailabilityServiceImplTest.java
@@ -1,0 +1,136 @@
+package com.shiftsync.shiftsync.availability.service;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityItemRequest;
+import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
+import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepository;
+import com.shiftsync.shiftsync.availability.service.impl.AvailabilityServiceImpl;
+import com.shiftsync.shiftsync.common.enums.EmploymentType;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AvailabilityServiceImplTest {
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private RecurringAvailabilityRepository recurringAvailabilityRepository;
+
+    @InjectMocks
+    private AvailabilityServiceImpl availabilityService;
+
+    private Employee employee;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .id(5L)
+                .email("employee@shiftsync.com")
+                .fullName("Employee One")
+                .passwordHash("hash")
+                .role(UserRole.EMPLOYEE)
+                .build();
+
+        employee = Employee.builder()
+                .id(10L)
+                .user(user)
+                .employmentType(EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("40.00"))
+                .hireDate(LocalDate.now())
+                .active(true)
+                .notificationEnabled(true)
+                .build();
+    }
+
+    @Test
+    void replaceRecurringAvailability_SameDayOverlap_ThrowsBadRequest() {
+        List<RecurringAvailabilityItemRequest> request = List.of(
+                new RecurringAvailabilityItemRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(13, 0)),
+                new RecurringAvailabilityItemRequest(DayOfWeek.MONDAY, LocalTime.of(12, 0), LocalTime.of(16, 0))
+        );
+
+        assertThatThrownBy(() -> availabilityService.replaceRecurringAvailability(5L, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Overlapping recurring availability windows are not allowed for MONDAY");
+
+        verify(employeeRepository, never()).findByUserId(5L);
+    }
+
+    @Test
+    void replaceRecurringAvailability_DifferentDays_AllowsSameTimeRange() {
+        List<RecurringAvailabilityItemRequest> request = List.of(
+                new RecurringAvailabilityItemRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(13, 0)),
+                new RecurringAvailabilityItemRequest(DayOfWeek.TUESDAY, LocalTime.of(9, 0), LocalTime.of(13, 0))
+        );
+
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
+        when(recurringAvailabilityRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        List<RecurringAvailabilityResponse> response = availabilityService.replaceRecurringAvailability(5L, request);
+
+        assertThat(response).hasSize(2);
+        verify(recurringAvailabilityRepository).deleteByEmployeeId(10L);
+    }
+
+    @Test
+    void replaceRecurringAvailability_AdjacentWindows_SameDay_AreAllowed() {
+        List<RecurringAvailabilityItemRequest> request = List.of(
+                new RecurringAvailabilityItemRequest(DayOfWeek.MONDAY, LocalTime.of(9, 0), LocalTime.of(13, 0)),
+                new RecurringAvailabilityItemRequest(DayOfWeek.MONDAY, LocalTime.of(13, 0), LocalTime.of(16, 0))
+        );
+
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
+        when(recurringAvailabilityRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        List<RecurringAvailabilityResponse> response = availabilityService.replaceRecurringAvailability(5L, request);
+
+        assertThat(response).hasSize(2);
+    }
+
+    @Test
+    void replaceRecurringAvailability_EmptyList_ClearsAndReturnsEmpty() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
+
+        List<RecurringAvailabilityResponse> response = availabilityService.replaceRecurringAvailability(5L, List.of());
+
+        assertThat(response).isEmpty();
+        verify(recurringAvailabilityRepository).deleteByEmployeeId(10L);
+        verify(recurringAvailabilityRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    void replaceRecurringAvailability_EndBeforeStart_ThrowsBadRequest() {
+        List<RecurringAvailabilityItemRequest> request = List.of(
+                new RecurringAvailabilityItemRequest(DayOfWeek.MONDAY, LocalTime.of(13, 0), LocalTime.of(9, 0))
+        );
+
+        assertThatThrownBy(() -> availabilityService.replaceRecurringAvailability(5L, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("endTime must be after startTime for MONDAY");
+    }
+}
+

--- a/src/test/java/com/shiftsync/shiftsync/availability/service/AvailabilityServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/availability/service/AvailabilityServiceImplTest.java
@@ -1,13 +1,19 @@
 package com.shiftsync.shiftsync.availability.service;
 
 import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.availability.dto.AvailabilityOverrideResponse;
+import com.shiftsync.shiftsync.availability.dto.CreateAvailabilityOverrideRequest;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityItemRequest;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
+import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
+import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepository;
 import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepository;
 import com.shiftsync.shiftsync.availability.service.impl.AvailabilityServiceImpl;
 import com.shiftsync.shiftsync.common.enums.EmploymentType;
 import com.shiftsync.shiftsync.common.enums.UserRole;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +33,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,6 +46,9 @@ class AvailabilityServiceImplTest {
 
     @Mock
     private RecurringAvailabilityRepository recurringAvailabilityRepository;
+
+    @Mock
+    private AvailabilityOverrideRepository availabilityOverrideRepository;
 
     @InjectMocks
     private AvailabilityServiceImpl availabilityService;
@@ -131,6 +141,93 @@ class AvailabilityServiceImplTest {
         assertThatThrownBy(() -> availabilityService.replaceRecurringAvailability(5L, request))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage("endTime must be after startTime for MONDAY");
+    }
+
+    @Test
+    void createOverride_ValidRequest_ReturnsCreatedOverride() {
+        CreateAvailabilityOverrideRequest request = new CreateAvailabilityOverrideRequest(
+                LocalDate.of(2026, 4, 10),
+                LocalDate.of(2026, 4, 12),
+                "Family event"
+        );
+
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
+        when(availabilityOverrideRepository.existsByEmployeeIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
+                10L, request.endDate(), request.startDate())).thenReturn(false);
+        when(availabilityOverrideRepository.save(any(AvailabilityOverride.class))).thenAnswer(invocation -> {
+            AvailabilityOverride override = invocation.getArgument(0);
+            override.setId(77L);
+            return override;
+        });
+
+        AvailabilityOverrideResponse response = availabilityService.createOverride(5L, request);
+
+        assertThat(response.id()).isEqualTo(77L);
+        assertThat(response.startDate()).isEqualTo(LocalDate.of(2026, 4, 10));
+        assertThat(response.endDate()).isEqualTo(LocalDate.of(2026, 4, 12));
+        verify(availabilityOverrideRepository).save(any(AvailabilityOverride.class));
+    }
+
+    @Test
+    void createOverride_Overlap_ThrowsConflict() {
+        CreateAvailabilityOverrideRequest request = new CreateAvailabilityOverrideRequest(
+                LocalDate.of(2026, 4, 10),
+                LocalDate.of(2026, 4, 12),
+                "Travel"
+        );
+
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
+        when(availabilityOverrideRepository.existsByEmployeeIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
+                10L, request.endDate(), request.startDate())).thenReturn(true);
+
+        assertThatThrownBy(() -> availabilityService.createOverride(5L, request))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Overlapping override dates are not allowed");
+
+        verify(availabilityOverrideRepository, never()).save(any(AvailabilityOverride.class));
+    }
+
+    @Test
+    void createOverride_EndBeforeStart_ThrowsBadRequest() {
+        CreateAvailabilityOverrideRequest request = new CreateAvailabilityOverrideRequest(
+                LocalDate.of(2026, 4, 12),
+                LocalDate.of(2026, 4, 10),
+                null
+        );
+
+        assertThatThrownBy(() -> availabilityService.createOverride(5L, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("endDate must be on or after startDate");
+    }
+
+    @Test
+    void listActiveOverrides_ReturnsOnlyRepositoryResults() {
+        AvailabilityOverride current = AvailabilityOverride.builder()
+                .id(1L)
+                .employee(employee)
+                .startDate(LocalDate.of(2026, 4, 10))
+                .endDate(LocalDate.of(2026, 4, 11))
+                .reason("Travel")
+                .build();
+
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
+        when(availabilityOverrideRepository.findByEmployeeIdAndEndDateGreaterThanEqualOrderByStartDateAsc(10L, LocalDate.now()))
+                .thenReturn(List.of(current));
+
+        List<AvailabilityOverrideResponse> response = availabilityService.listActiveOverrides(5L);
+
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().id()).isEqualTo(1L);
+    }
+
+    @Test
+    void deleteOverride_NotOwned_ThrowsNotFound() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
+        when(availabilityOverrideRepository.findByIdAndEmployeeId(99L, 10L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> availabilityService.deleteOverride(5L, 99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Availability override not found");
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/availability/service/AvailabilityServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/availability/service/AvailabilityServiceImplTest.java
@@ -3,9 +3,11 @@ package com.shiftsync.shiftsync.availability.service;
 import com.shiftsync.shiftsync.auth.entity.User;
 import com.shiftsync.shiftsync.availability.dto.AvailabilityOverrideResponse;
 import com.shiftsync.shiftsync.availability.dto.CreateAvailabilityOverrideRequest;
+import com.shiftsync.shiftsync.availability.dto.ManagerWeeklyAvailabilityResponse;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityItemRequest;
 import com.shiftsync.shiftsync.availability.dto.RecurringAvailabilityResponse;
 import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
+import com.shiftsync.shiftsync.availability.entity.RecurringAvailability;
 import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepository;
 import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepository;
 import com.shiftsync.shiftsync.availability.service.impl.AvailabilityServiceImpl;
@@ -16,12 +18,14 @@ import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
@@ -49,6 +53,9 @@ class AvailabilityServiceImplTest {
 
     @Mock
     private AvailabilityOverrideRepository availabilityOverrideRepository;
+
+    @Mock
+    private ManagerLocationRepository managerLocationRepository;
 
     @InjectMocks
     private AvailabilityServiceImpl availabilityService;
@@ -152,8 +159,7 @@ class AvailabilityServiceImplTest {
         );
 
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
-        when(availabilityOverrideRepository.existsByEmployeeIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
-                10L, request.endDate(), request.startDate())).thenReturn(false);
+        when(availabilityOverrideRepository.hasOverlap(10L, request.startDate(), request.endDate())).thenReturn(false);
         when(availabilityOverrideRepository.save(any(AvailabilityOverride.class))).thenAnswer(invocation -> {
             AvailabilityOverride override = invocation.getArgument(0);
             override.setId(77L);
@@ -177,8 +183,7 @@ class AvailabilityServiceImplTest {
         );
 
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
-        when(availabilityOverrideRepository.existsByEmployeeIdAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
-                10L, request.endDate(), request.startDate())).thenReturn(true);
+        when(availabilityOverrideRepository.hasOverlap(10L, request.startDate(), request.endDate())).thenReturn(true);
 
         assertThatThrownBy(() -> availabilityService.createOverride(5L, request))
                 .isInstanceOf(InvalidStateException.class)
@@ -211,7 +216,7 @@ class AvailabilityServiceImplTest {
                 .build();
 
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
-        when(availabilityOverrideRepository.findByEmployeeIdAndEndDateGreaterThanEqualOrderByStartDateAsc(10L, LocalDate.now()))
+        when(availabilityOverrideRepository.findActiveByEmployee(10L, LocalDate.now()))
                 .thenReturn(List.of(current));
 
         List<AvailabilityOverrideResponse> response = availabilityService.listActiveOverrides(5L);
@@ -228,6 +233,98 @@ class AvailabilityServiceImplTest {
         assertThatThrownBy(() -> availabilityService.deleteOverride(5L, 99L))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("Availability override not found");
+    }
+
+    @Test
+    void getLocationWeeklyAvailability_ManagerNotAssigned_ThrowsForbidden() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(2L));
+
+        assertThatThrownBy(() -> availabilityService.getLocationWeeklyAvailability(5L, 1L, LocalDate.of(2026, 4, 8)))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("You are not assigned to this location");
+    }
+
+    @Test
+    void getLocationWeeklyAvailability_MergesRecurringMinusOverrides() {
+        User managerUser = User.builder()
+                .id(5L)
+                .email("manager@shiftsync.com")
+                .fullName("Manager One")
+                .passwordHash("hash")
+                .role(UserRole.MANAGER)
+                .build();
+
+        Employee manager = Employee.builder()
+                .id(10L)
+                .user(managerUser)
+                .employmentType(EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("40.00"))
+                .hireDate(LocalDate.now())
+                .active(true)
+                .notificationEnabled(true)
+                .build();
+
+        User teamUser = User.builder()
+                .id(7L)
+                .email("employee2@shiftsync.com")
+                .fullName("Employee Two")
+                .passwordHash("hash")
+                .role(UserRole.EMPLOYEE)
+                .build();
+
+        Employee teamMember = Employee.builder()
+                .id(20L)
+                .user(teamUser)
+                .employmentType(EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("40.00"))
+                .hireDate(LocalDate.now())
+                .active(true)
+                .notificationEnabled(true)
+                .build();
+
+        RecurringAvailability mondayWindow = RecurringAvailability.builder()
+                .employee(teamMember)
+                .dayOfWeek(DayOfWeek.MONDAY)
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(13, 0))
+                .build();
+
+        RecurringAvailability tuesdayWindow = RecurringAvailability.builder()
+                .employee(teamMember)
+                .dayOfWeek(DayOfWeek.TUESDAY)
+                .startTime(LocalTime.of(10, 0))
+                .endTime(LocalTime.of(14, 0))
+                .build();
+
+        AvailabilityOverride mondayOverride = AvailabilityOverride.builder()
+                .employee(teamMember)
+                .startDate(LocalDate.of(2026, 4, 6))
+                .endDate(LocalDate.of(2026, 4, 6))
+                .reason("Personal")
+                .build();
+
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
+        when(employeeRepository.findByLocationIdAndActiveTrueWithUser(1L)).thenReturn(List.of(teamMember));
+        when(recurringAvailabilityRepository.findByEmployeeIdIn(List.of(20L))).thenReturn(List.of(mondayWindow, tuesdayWindow));
+        when(availabilityOverrideRepository.findWeekOverlaps(
+                List.of(20L), LocalDate.of(2026, 4, 6), LocalDate.of(2026, 4, 12)))
+                .thenReturn(List.of(mondayOverride));
+
+        ManagerWeeklyAvailabilityResponse response = availabilityService.getLocationWeeklyAvailability(5L, 1L, LocalDate.of(2026, 4, 8));
+
+        assertThat(response.weekStart()).isEqualTo(LocalDate.of(2026, 4, 6));
+        assertThat(response.weekEnd()).isEqualTo(LocalDate.of(2026, 4, 12));
+        assertThat(response.employees()).hasSize(1);
+
+        List<ManagerWeeklyAvailabilityResponse.DailyAvailability> days = response.employees().getFirst().days();
+        assertThat(days).hasSize(7);
+        assertThat(days.getFirst().overridden()).isTrue();
+        assertThat(days.getFirst().windows()).isEmpty();
+        assertThat(days.get(1).overridden()).isFalse();
+        assertThat(days.get(1).windows()).hasSize(1);
+        assertThat(days.get(1).windows().getFirst().startTime()).isEqualTo(LocalTime.of(10, 0));
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftAssignmentControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftAssignmentControllerWebMvcTest.java
@@ -1,6 +1,7 @@
 package com.shiftsync.shiftsync.shift.controller;
 
 import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.common.exception.UnprocessableEntityException;
 import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
 import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
 import com.shiftsync.shiftsync.config.security.JwtService;
@@ -22,6 +23,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -96,6 +98,19 @@ class ShiftAssignmentControllerWebMvcTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"employeeId\":20}"))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "MANAGER")
+    void assignEmployee_InactiveEmployee_ReturnsUnprocessableEntity() throws Exception {
+        doThrow(new UnprocessableEntityException("Cannot assign an inactive employee to a shift"))
+                .when(shiftAssignmentService)
+                .assignEmployee(anyLong(), eq(100L), any(), eq(false));
+
+        mockMvc.perform(post("/api/v1/shifts/100/assignments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"employeeId\":20}"))
+                .andExpect(status().isUnprocessableContent());
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftAssignmentControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftAssignmentControllerWebMvcTest.java
@@ -1,0 +1,102 @@
+package com.shiftsync.shiftsync.shift.controller;
+
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import com.shiftsync.shiftsync.shift.dto.AssignEmployeeResponse;
+import com.shiftsync.shiftsync.shift.service.ShiftAssignmentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ShiftAssignmentController.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, AuthenticationHelper.class})
+class ShiftAssignmentControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ShiftAssignmentService shiftAssignmentService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Test
+    void assignEmployee_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/v1/shifts/100/assignments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"employeeId\":20}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "MANAGER")
+    void assignEmployee_AvailabilityWarning_ReturnsOk() throws Exception {
+        when(shiftAssignmentService.assignEmployee(anyLong(), eq(100L), any(), eq(false)))
+                .thenReturn(new AssignEmployeeResponse(
+                        "WARNING",
+                        List.of("AVAILABILITY_MISMATCH"),
+                        "Employee availability does not match this shift. Re-submit with override=true to proceed.",
+                        null
+                ));
+
+        mockMvc.perform(post("/api/v1/shifts/100/assignments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"employeeId\":20}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("WARNING"));
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "MANAGER")
+    void assignEmployee_WithOverride_CreatesAssignment() throws Exception {
+        when(shiftAssignmentService.assignEmployee(anyLong(), eq(100L), any(), eq(true)))
+                .thenReturn(new AssignEmployeeResponse(
+                        "ASSIGNED",
+                        List.of(),
+                        "Employee assigned successfully",
+                        200L
+                ));
+
+        mockMvc.perform(post("/api/v1/shifts/100/assignments")
+                        .queryParam("override", "true")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"employeeId\":20}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.assignmentId").value(200));
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void assignEmployee_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(post("/api/v1/shifts/100/assignments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"employeeId\":20}"))
+                .andExpect(status().isForbidden());
+    }
+}
+
+

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
@@ -1,0 +1,224 @@
+package com.shiftsync.shiftsync.shift.service;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.auth.repository.UserRepository;
+import com.shiftsync.shiftsync.availability.entity.RecurringAvailability;
+import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepository;
+import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepository;
+import com.shiftsync.shiftsync.common.enums.EmploymentType;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
+import com.shiftsync.shiftsync.shift.dto.AssignEmployeeRequest;
+import com.shiftsync.shiftsync.shift.dto.AssignEmployeeResponse;
+import com.shiftsync.shiftsync.shift.entity.Shift;
+import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
+import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
+import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
+import com.shiftsync.shiftsync.shift.repository.ShiftRepository;
+import com.shiftsync.shiftsync.shift.service.impl.ShiftAssignmentServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ShiftAssignmentServiceImplTest {
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ShiftRepository shiftRepository;
+
+    @Mock
+    private ShiftAssignmentRepository shiftAssignmentRepository;
+
+    @Mock
+    private ManagerLocationRepository managerLocationRepository;
+
+    @Mock
+    private RecurringAvailabilityRepository recurringAvailabilityRepository;
+
+    @Mock
+    private AvailabilityOverrideRepository availabilityOverrideRepository;
+
+    @InjectMocks
+    private ShiftAssignmentServiceImpl shiftAssignmentService;
+
+    private Employee manager;
+    private Employee employee;
+    private Shift shift;
+    private User managerUser;
+
+    @BeforeEach
+    void setUp() {
+        managerUser = User.builder()
+                .id(5L)
+                .email("manager@shiftsync.com")
+                .passwordHash("hash")
+                .fullName("Manager")
+                .role(UserRole.MANAGER)
+                .build();
+
+        User employeeUser = User.builder()
+                .id(7L)
+                .email("employee@shiftsync.com")
+                .passwordHash("hash")
+                .fullName("Employee")
+                .role(UserRole.EMPLOYEE)
+                .build();
+
+        manager = Employee.builder()
+                .id(10L)
+                .user(managerUser)
+                .employmentType(EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("40.00"))
+                .hireDate(LocalDate.of(2026, 1, 1))
+                .active(true)
+                .notificationEnabled(true)
+                .build();
+
+        employee = Employee.builder()
+                .id(20L)
+                .user(employeeUser)
+                .employmentType(EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("40.00"))
+                .hireDate(LocalDate.of(2026, 1, 1))
+                .active(true)
+                .notificationEnabled(true)
+                .build();
+
+        Location location = Location.builder()
+                .id(1L)
+                .name("Main")
+                .address("Accra")
+                .maxHeadcountPerShift(10)
+                .active(true)
+                .build();
+
+        shift = Shift.builder()
+                .id(100L)
+                .location(location)
+                .shiftDate(LocalDate.of(2026, 4, 7))
+                .startTime(LocalTime.of(9, 0))
+                .endTime(LocalTime.of(13, 0))
+                .minimumHeadcount(1)
+                .status(ShiftStatus.OPEN)
+                .createdBy(managerUser)
+                .build();
+    }
+
+    @Test
+    void assignEmployee_OutsideAvailability_ReturnsWarningAndDoesNotSave() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
+        when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
+        when(availabilityOverrideRepository.hasOverlap(20L, LocalDate.of(2026, 4, 7), LocalDate.of(2026, 4, 7))).thenReturn(false);
+        when(recurringAvailabilityRepository.findByEmployeeAndDay(20L, DayOfWeek.TUESDAY)).thenReturn(List.of());
+
+        AssignEmployeeResponse response = shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false);
+
+        assertThat(response.status()).isEqualTo("WARNING");
+        assertThat(response.conflicts()).containsExactly("AVAILABILITY_MISMATCH");
+        verify(shiftAssignmentRepository, never()).save(any(ShiftAssignment.class));
+    }
+
+    @Test
+    void assignEmployee_OutsideAvailabilityWithOverride_CreatesAssignment() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
+        when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
+        when(availabilityOverrideRepository.hasOverlap(20L, LocalDate.of(2026, 4, 7), LocalDate.of(2026, 4, 7))).thenReturn(true);
+        when(userRepository.findById(5L)).thenReturn(Optional.of(managerUser));
+        when(shiftAssignmentRepository.save(any(ShiftAssignment.class))).thenAnswer(invocation -> {
+            ShiftAssignment saved = invocation.getArgument(0);
+            saved.setId(999L);
+            return saved;
+        });
+
+        AssignEmployeeResponse response = shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), true);
+
+        assertThat(response.status()).isEqualTo("ASSIGNED");
+        assertThat(response.assignmentId()).isEqualTo(999L);
+    }
+
+    @Test
+    void assignEmployee_WithinAvailability_CreatesAssignmentWithoutOverrideFlag() {
+        RecurringAvailability recurring = RecurringAvailability.builder()
+                .employee(employee)
+                .dayOfWeek(DayOfWeek.TUESDAY)
+                .startTime(LocalTime.of(8, 0))
+                .endTime(LocalTime.of(17, 0))
+                .build();
+
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
+        when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
+        when(availabilityOverrideRepository.hasOverlap(20L, LocalDate.of(2026, 4, 7), LocalDate.of(2026, 4, 7))).thenReturn(false);
+        when(recurringAvailabilityRepository.findByEmployeeAndDay(20L, DayOfWeek.TUESDAY)).thenReturn(List.of(recurring));
+        when(userRepository.findById(5L)).thenReturn(Optional.of(managerUser));
+        when(shiftAssignmentRepository.save(any(ShiftAssignment.class))).thenAnswer(invocation -> {
+            ShiftAssignment saved = invocation.getArgument(0);
+            saved.setId(111L);
+            return saved;
+        });
+
+        AssignEmployeeResponse response = shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false);
+
+        assertThat(response.status()).isEqualTo("ASSIGNED");
+        assertThat(response.assignmentId()).isEqualTo(111L);
+    }
+
+    @Test
+    void assignEmployee_ManagerNotAssignedToLocation_ThrowsForbidden() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(2L));
+
+        assertThatThrownBy(() -> shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("You are not assigned to this location");
+    }
+
+    @Test
+    void assignEmployee_CancelledShift_ThrowsConflict() {
+        shift.setStatus(ShiftStatus.CANCELLED);
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+
+        assertThatThrownBy(() -> shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Cannot assign employees to a cancelled shift");
+    }
+}
+

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
@@ -8,6 +8,7 @@ import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepo
 import com.shiftsync.shiftsync.common.enums.EmploymentType;
 import com.shiftsync.shiftsync.common.enums.UserRole;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.exception.UnprocessableEntityException;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.location.entity.Location;
@@ -219,6 +220,20 @@ class ShiftAssignmentServiceImplTest {
         assertThatThrownBy(() -> shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false))
                 .isInstanceOf(InvalidStateException.class)
                 .hasMessage("Cannot assign employees to a cancelled shift");
+    }
+
+    @Test
+    void assignEmployee_InactiveEmployee_ThrowsUnprocessableEntity() {
+        employee.setActive(false);
+
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
+
+        assertThatThrownBy(() -> shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false))
+                .isInstanceOf(UnprocessableEntityException.class)
+                .hasMessage("Cannot assign an inactive employee to a shift");
     }
 }
 


### PR DESCRIPTION
## What
Implements **Epic 4: Availability Management** end-to-end:

- **US-AVAIL-01**: `PUT /api/v1/employees/me/availability/recurring`
  - Replaces recurring weekly availability
  - Validates `endTime > startTime`
  - Rejects same-day overlaps with `400`
  - Empty list clears recurring schedule
- **US-AVAIL-02**: one-off overrides
  - `POST /api/v1/employees/me/availability/overrides`
  - `GET /api/v1/employees/me/availability/overrides`
  - `DELETE /api/v1/employees/me/availability/overrides/{id}`
  - Overlapping date ranges return `409`
- **US-AVAIL-03**: manager weekly team availability
  - `GET /api/v1/locations/{locationId}/availability?week=YYYY-MM-DD`
  - Returns week-normalized (Mon-Sun) per-employee daily availability
  - Merges recurring windows minus override dates
  - Enforces manager-location assignment (`403` if not assigned)
- **US-AVAIL-04**: assignment warning/override flow
  - `POST /api/v1/shifts/{shiftId}/assignments`
  - Returns `200` warning payload for availability mismatch:
    - `status: "WARNING"`
    - `conflicts: ["AVAILABILITY_MISMATCH"]`
  - Requires `?override=true` to proceed on mismatch
  - On override, persists assignment with `override_applied=true` and `override_reason="AVAILABILITY_MISMATCH"`

## Why
Implements the availability planning and enforcement workflow required by:

- `US-AVAIL-01`: recurring employee availability declaration
- `US-AVAIL-02`: date-based one-off unavailability
- `US-AVAIL-03`: manager weekly team visibility
- `US-AVAIL-04`: soft warning + explicit override before out-of-availability assignment

This gives managers planning visibility while preserving intentional override control and traceability.

## How to test
1. **Recurring availability (employee)**
   - `PUT /api/v1/employees/me/availability/recurring` with valid windows -> `200`
   - Submit same-day overlapping windows -> `400`
   - Submit `[]` -> `200` and cleared schedule

2. **Overrides (employee)**
   - `POST /api/v1/employees/me/availability/overrides` with non-overlapping dates -> `201`
   - Create overlapping override -> `409`
   - `GET /api/v1/employees/me/availability/overrides` -> active overrides list
   - `DELETE /api/v1/employees/me/availability/overrides/{id}` -> `204`

3. **Weekly team availability (manager)**
   - `GET /api/v1/locations/{locationId}/availability?week=2026-04-08` (assigned location) -> `200`
   - Same endpoint for non-assigned location -> `403`

4. **Assignment warning/override flow (manager)**
   - `POST /api/v1/shifts/{shiftId}/assignments` (outside availability) -> `200` warning payload
   - Re-submit with `?override=true` -> `201` assignment created
   - Within availability -> `201` directly

### Automated tests
Test files:

- `src/test/java/com/shiftsync/shiftsync/availability/service/AvailabilityServiceImplTest.java`
- `src/test/java/com/shiftsync/shiftsync/availability/controller/AvailabilityControllerWebMvcTest.java`
- `src/test/java/com/shiftsync/shiftsync/availability/controller/ManagerAvailabilityControllerWebMvcTest.java`
- `src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java`
- `src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftAssignmentControllerWebMvcTest.java`

Targeted test command used:

```powershell
.\mvnw.cmd "-Dtest=ShiftAssignmentServiceImplTest,ShiftAssignmentControllerWebMvcTest,AvailabilityServiceImplTest,AvailabilityControllerWebMvcTest,ManagerAvailabilityControllerWebMvcTest" test
```

## Notes
- **Versioning deviation**: endpoints use `/api/v1/...` while stories use `/api/...` without version segment. This is an intentional API versioning decision applied consistently.
- **US-AVAIL-03 cache clause deferred**: story mentions cache + invalidation; caching is intentionally deferred for now (agreed clarification), and current implementation is non-cached(caching will be done for all on week 5).
- **US-AVAIL-04 dependency bridge**: minimal shift-assignment endpoint/entities were added to support availability warning + override behavior required by this story.
