### PR TITLE
feat: Implement leave request management with creation, approval, and filters

### DIFF
--- a/src/main/java/com/shiftsync/shiftsync/availability/entity/AvailabilityOverride.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/entity/AvailabilityOverride.java
@@ -1,0 +1,67 @@
+package com.shiftsync.shiftsync.availability.entity;
+
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "availability_overrides")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AvailabilityOverride {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employee_id", nullable = false)
+    private Employee employee;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "reason")
+    private String reason;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/availability/entity/AvailabilityOverride.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/entity/AvailabilityOverride.java
@@ -1,8 +1,11 @@
 package com.shiftsync.shiftsync.availability.entity;
 
+import com.shiftsync.shiftsync.common.enums.OverrideSource;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -46,6 +49,10 @@ public class AvailabilityOverride {
 
     @Column(name = "reason")
     private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source", nullable = false)
+    private OverrideSource source;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/shiftsync/shiftsync/availability/repository/AvailabilityOverrideRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/repository/AvailabilityOverrideRepository.java
@@ -3,12 +3,8 @@ package com.shiftsync.shiftsync.availability.repository;
 import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-@Repository
-public interface AvailabilityOverrideRepository extends JpaRepository<AvailabilityOverride, Long> {
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/shiftsync/shiftsync/availability/repository/AvailabilityOverrideRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/availability/repository/AvailabilityOverrideRepository.java
@@ -1,0 +1,10 @@
+package com.shiftsync.shiftsync.availability.repository;
+
+import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AvailabilityOverrideRepository extends JpaRepository<AvailabilityOverride, Long> {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/common/enums/LeaveStatus.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/enums/LeaveStatus.java
@@ -1,0 +1,9 @@
+package com.shiftsync.shiftsync.common.enums;
+
+public enum LeaveStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+    CANCELLED
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/common/enums/LeaveType.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/enums/LeaveType.java
@@ -1,0 +1,8 @@
+package com.shiftsync.shiftsync.common.enums;
+
+public enum LeaveType {
+    ANNUAL,
+    SICK,
+    UNPAID
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/common/enums/NotificationType.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/enums/NotificationType.java
@@ -1,0 +1,11 @@
+package com.shiftsync.shiftsync.common.enums;
+
+public enum NotificationType {
+    SHIFT_ASSIGNED,
+    SHIFT_REMOVED,
+    SHIFT_CANCELLED,
+    SHIFT_CHANGED,
+    LEAVE_UPDATED,
+    SWAP_OUTCOME,
+    LEAVE_CONFLICT
+}

--- a/src/main/java/com/shiftsync/shiftsync/common/enums/OverrideSource.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/enums/OverrideSource.java
@@ -1,0 +1,6 @@
+package com.shiftsync.shiftsync.common.enums;
+
+public enum OverrideSource {
+    LEAVE_APPROVAL,
+    EMPLOYEE_DECLARED
+}

--- a/src/main/java/com/shiftsync/shiftsync/common/exception/BadRequestException.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package com.shiftsync.shiftsync.common.exception;
+
+public class BadRequestException extends RuntimeException {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/exception/GlobalExceptionHandler.java
@@ -77,6 +77,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
 
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleBadRequest(BadRequestException ex) {
+        log.warn("Bad request: {}", ex.getMessage());
+        ErrorResponse response = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad Request",
+                ex.getMessage()
+        );
+        return ResponseEntity.badRequest().body(response);
+    }
+
     @ExceptionHandler(InvalidStateException.class)
     public ResponseEntity<ErrorResponse> handleInvalidState(InvalidStateException ex) {
         log.warn("Invalid resource state: {}", ex.getMessage());

--- a/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -138,6 +139,28 @@ public class LeaveRequestController {
     ) {
         Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
         LeaveRequestResponse response = leaveRequestService.rejectLeaveRequest(actorUserId, id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    @Operation(
+            summary = "Cancel pending leave request",
+            description = "Cancels the authenticated employee's own pending leave request."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Leave request cancelled", content = @Content(schema = @Schema(implementation = LeaveRequestResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Leave request not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Leave request cannot be cancelled", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LeaveRequestResponse> cancelLeaveRequest(
+            Authentication authentication,
+            @PathVariable Long id
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        LeaveRequestResponse response = leaveRequestService.cancelLeaveRequest(actorUserId, id);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
@@ -3,7 +3,9 @@ package com.shiftsync.shiftsync.leave.controller;
 import com.shiftsync.shiftsync.common.response.ErrorResponse;
 import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
+import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
 import com.shiftsync.shiftsync.leave.service.LeaveRequestService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -17,10 +19,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/v1/leave-requests")
@@ -51,6 +57,36 @@ public class LeaveRequestController {
         Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
         LeaveRequestResponse response = leaveRequestService.createLeaveRequest(actorUserId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(
+            summary = "Get pending leave requests",
+            description = "Returns paginated pending leave requests with optional employee, location, and date-range filters."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pending leave requests retrieved", content = @Content(schema = @Schema(implementation = PendingLeaveRequestPageResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<PendingLeaveRequestPageResponse> getPendingLeaveRequests(
+            @RequestParam(required = false) Long employeeId,
+            @RequestParam(required = false) Long locationId,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        GetPendingLeaveRequestsRequest request = new GetPendingLeaveRequestsRequest(
+                employeeId,
+                locationId,
+                startDate,
+                endDate,
+                page,
+                size
+        );
+        return ResponseEntity.ok(leaveRequestService.getPendingLeaveRequests(request));
     }
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
@@ -7,6 +7,7 @@ import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
 import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
+import com.shiftsync.shiftsync.leave.dto.RejectLeaveRequest;
 import com.shiftsync.shiftsync.leave.service.LeaveRequestService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -113,6 +114,30 @@ public class LeaveRequestController {
     ) {
         Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
         LeaveRequestResponse response = leaveRequestService.approveLeaveRequest(actorUserId, id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{id}/reject")
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(
+            summary = "Reject leave request",
+            description = "Rejects a pending leave request and stores the HR note."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Leave request rejected", content = @Content(schema = @Schema(implementation = LeaveRequestResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Leave request not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Leave request is not pending", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LeaveRequestResponse> rejectLeaveRequest(
+            Authentication authentication,
+            @PathVariable Long id,
+            @Valid @RequestBody RejectLeaveRequest request
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        LeaveRequestResponse response = leaveRequestService.rejectLeaveRequest(actorUserId, id, request);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
@@ -2,6 +2,7 @@ package com.shiftsync.shiftsync.leave.controller;
 
 import com.shiftsync.shiftsync.common.response.ErrorResponse;
 import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.leave.dto.ApproveLeaveRequest;
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
 import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
@@ -20,6 +21,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -87,6 +90,30 @@ public class LeaveRequestController {
                 size
         );
         return ResponseEntity.ok(leaveRequestService.getPendingLeaveRequests(request));
+    }
+
+    @PatchMapping("/{id}/approve")
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(
+            summary = "Approve leave request",
+            description = "Approves a pending leave request, stores HR note, and blocks employee availability for the leave period."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Leave request approved", content = @Content(schema = @Schema(implementation = LeaveRequestResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Leave request not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Leave request is not pending", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LeaveRequestResponse> approveLeaveRequest(
+            Authentication authentication,
+            @PathVariable Long id,
+            @Valid @RequestBody ApproveLeaveRequest request
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        LeaveRequestResponse response = leaveRequestService.approveLeaveRequest(actorUserId, id, request);
+        return ResponseEntity.ok(response);
     }
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
@@ -1,10 +1,11 @@
 package com.shiftsync.shiftsync.leave.controller;
 
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
 import com.shiftsync.shiftsync.common.response.ErrorResponse;
 import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.leave.dto.ApproveLeaveRequest;
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
-import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
+import com.shiftsync.shiftsync.leave.dto.GetLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
 import com.shiftsync.shiftsync.leave.dto.RejectLeaveRequest;
@@ -67,31 +68,33 @@ public class LeaveRequestController {
     @GetMapping
     @PreAuthorize("hasRole('HR_ADMIN')")
     @Operation(
-            summary = "Get pending leave requests",
-            description = "Returns paginated pending leave requests with optional employee, location, and date-range filters."
+            summary = "Get leave requests",
+            description = "Returns paginated leave requests with optional employee, location, status, and date-range filters (FR-LEAVE-06)."
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Pending leave requests retrieved", content = @Content(schema = @Schema(implementation = PendingLeaveRequestPageResponse.class))),
+            @ApiResponse(responseCode = "200", description = "Leave requests retrieved", content = @Content(schema = @Schema(implementation = PendingLeaveRequestPageResponse.class))),
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<PendingLeaveRequestPageResponse> getPendingLeaveRequests(
+    public ResponseEntity<PendingLeaveRequestPageResponse> getLeaveRequests(
             @RequestParam(required = false) Long employeeId,
             @RequestParam(required = false) Long locationId,
+            @RequestParam(required = false) LeaveStatus status,
             @RequestParam(required = false) LocalDate startDate,
             @RequestParam(required = false) LocalDate endDate,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        GetPendingLeaveRequestsRequest request = new GetPendingLeaveRequestsRequest(
+        GetLeaveRequestsRequest request = new GetLeaveRequestsRequest(
                 employeeId,
                 locationId,
+                status,
                 startDate,
                 endDate,
                 page,
                 size
         );
-        return ResponseEntity.ok(leaveRequestService.getPendingLeaveRequests(request));
+        return ResponseEntity.ok(leaveRequestService.getLeaveRequests(request));
     }
 
     @PatchMapping("/{id}/approve")

--- a/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestController.java
@@ -1,0 +1,56 @@
+package com.shiftsync.shiftsync.leave.controller;
+
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
+import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.service.LeaveRequestService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/leave-requests")
+@RequiredArgsConstructor
+@Tag(name = "Leave Requests", description = "Leave request management endpoints")
+public class LeaveRequestController {
+
+    private final LeaveRequestService leaveRequestService;
+    private final AuthenticationHelper authenticationHelper;
+
+    @PostMapping
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    @Operation(
+            summary = "Submit leave request",
+            description = "Creates a leave request in PENDING status for the authenticated employee."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Leave request submitted", content = @Content(schema = @Schema(implementation = LeaveRequestResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Overlapping leave request", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LeaveRequestResponse> createLeaveRequest(
+            Authentication authentication,
+            @Valid @RequestBody CreateLeaveRequest request
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        LeaveRequestResponse response = leaveRequestService.createLeaveRequest(actorUserId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/dto/ApproveLeaveRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/dto/ApproveLeaveRequest.java
@@ -1,0 +1,10 @@
+package com.shiftsync.shiftsync.leave.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ApproveLeaveRequest(
+        @NotBlank(message = "HR note is required")
+        String hrNote
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/dto/CreateLeaveRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/dto/CreateLeaveRequest.java
@@ -1,0 +1,23 @@
+package com.shiftsync.shiftsync.leave.dto;
+
+import com.shiftsync.shiftsync.common.enums.LeaveType;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record CreateLeaveRequest(
+        @NotNull(message = "Start date is required")
+        @FutureOrPresent(message = "Start date cannot be in the past")
+        LocalDate startDate,
+
+        @NotNull(message = "End date is required")
+        LocalDate endDate,
+
+        @NotNull(message = "Leave type is required")
+        LeaveType leaveType,
+
+        String reason
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/dto/GetLeaveRequestsRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/dto/GetLeaveRequestsRequest.java
@@ -1,14 +1,16 @@
 package com.shiftsync.shiftsync.leave.dto;
 
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+
 import java.time.LocalDate;
 
-public record GetPendingLeaveRequestsRequest(
+public record GetLeaveRequestsRequest(
         Long employeeId,
         Long locationId,
+        LeaveStatus status,
         LocalDate startDate,
         LocalDate endDate,
         int page,
         int size
 ) {
 }
-

--- a/src/main/java/com/shiftsync/shiftsync/leave/dto/GetPendingLeaveRequestsRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/dto/GetPendingLeaveRequestsRequest.java
@@ -1,0 +1,14 @@
+package com.shiftsync.shiftsync.leave.dto;
+
+import java.time.LocalDate;
+
+public record GetPendingLeaveRequestsRequest(
+        Long employeeId,
+        Long locationId,
+        LocalDate startDate,
+        LocalDate endDate,
+        int page,
+        int size
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/dto/LeaveRequestResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/dto/LeaveRequestResponse.java
@@ -1,0 +1,20 @@
+package com.shiftsync.shiftsync.leave.dto;
+
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.enums.LeaveType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record LeaveRequestResponse(
+        Long id,
+        Long employeeId,
+        LocalDate startDate,
+        LocalDate endDate,
+        LeaveType leaveType,
+        String reason,
+        LeaveStatus status,
+        LocalDateTime submittedAt
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/dto/PendingLeaveRequestPageResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/dto/PendingLeaveRequestPageResponse.java
@@ -1,0 +1,12 @@
+package com.shiftsync.shiftsync.leave.dto;
+
+import java.util.List;
+
+public record PendingLeaveRequestPageResponse(
+        List<PendingLeaveRequestResponse> content,
+        long totalElements,
+        int totalPages,
+        int currentPage
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/dto/PendingLeaveRequestResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/dto/PendingLeaveRequestResponse.java
@@ -1,0 +1,23 @@
+package com.shiftsync.shiftsync.leave.dto;
+
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.enums.LeaveType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record PendingLeaveRequestResponse(
+        Long id,
+        Long employeeId,
+        String employeeName,
+        String department,
+        LocalDate startDate,
+        LocalDate endDate,
+        LeaveType leaveType,
+        long daysRequested,
+        String reason,
+        LeaveStatus status,
+        LocalDateTime submittedAt
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/dto/RejectLeaveRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/dto/RejectLeaveRequest.java
@@ -1,0 +1,10 @@
+package com.shiftsync.shiftsync.leave.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RejectLeaveRequest(
+        @NotBlank(message = "HR note is required")
+        String hrNote
+) {
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/entity/LeaveRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/entity/LeaveRequest.java
@@ -67,11 +67,11 @@ public class LeaveRequest {
     private String hrNote;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "approved_by")
-    private User approvedBy;
+    @JoinColumn(name = "reviewed_by")
+    private User reviewedBy;
 
-    @Column(name = "approved_at")
-    private LocalDateTime approvedAt;
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
 
     @Column(name = "submitted_at", nullable = false)
     private LocalDateTime submittedAt;

--- a/src/main/java/com/shiftsync/shiftsync/leave/entity/LeaveRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/entity/LeaveRequest.java
@@ -1,0 +1,102 @@
+package com.shiftsync.shiftsync.leave.entity;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.enums.LeaveType;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "leave_requests")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LeaveRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employee_id", nullable = false)
+    private Employee employee;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "?::leave_type")
+    @Column(name = "leave_type", nullable = false)
+    private LeaveType leaveType;
+
+    @Column(name = "reason")
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "?::leave_status")
+    @Column(name = "status", nullable = false)
+    private LeaveStatus status;
+
+    @Column(name = "hr_note")
+    private String hrNote;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "approved_by")
+    private User approvedBy;
+
+    @Column(name = "approved_at")
+    private LocalDateTime approvedAt;
+
+    @Column(name = "submitted_at", nullable = false)
+    private LocalDateTime submittedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (status == null) {
+            status = LeaveStatus.PENDING;
+        }
+        if (submittedAt == null) {
+            submittedAt = LocalDateTime.now();
+        }
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/mapper/LeaveRequestMapper.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/mapper/LeaveRequestMapper.java
@@ -1,0 +1,23 @@
+package com.shiftsync.shiftsync.leave.mapper;
+
+import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LeaveRequestMapper {
+
+    public LeaveRequestResponse toResponse(LeaveRequest leaveRequest) {
+        return new LeaveRequestResponse(
+                leaveRequest.getId(),
+                leaveRequest.getEmployee().getId(),
+                leaveRequest.getStartDate(),
+                leaveRequest.getEndDate(),
+                leaveRequest.getLeaveType(),
+                leaveRequest.getReason(),
+                leaveRequest.getStatus(),
+                leaveRequest.getSubmittedAt()
+        );
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/mapper/LeaveRequestMapper.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/mapper/LeaveRequestMapper.java
@@ -1,8 +1,11 @@
 package com.shiftsync.shiftsync.leave.mapper;
 
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
 import org.springframework.stereotype.Component;
+
+import java.time.temporal.ChronoUnit;
 
 @Component
 public class LeaveRequestMapper {
@@ -14,6 +17,24 @@ public class LeaveRequestMapper {
                 leaveRequest.getStartDate(),
                 leaveRequest.getEndDate(),
                 leaveRequest.getLeaveType(),
+                leaveRequest.getReason(),
+                leaveRequest.getStatus(),
+                leaveRequest.getSubmittedAt()
+        );
+    }
+
+    public PendingLeaveRequestResponse toPendingResponse(LeaveRequest leaveRequest) {
+        long daysRequested = ChronoUnit.DAYS.between(leaveRequest.getStartDate(), leaveRequest.getEndDate()) + 1;
+
+        return new PendingLeaveRequestResponse(
+                leaveRequest.getId(),
+                leaveRequest.getEmployee().getId(),
+                leaveRequest.getEmployee().getUser().getFullName(),
+                leaveRequest.getEmployee().getDepartment().getName(),
+                leaveRequest.getStartDate(),
+                leaveRequest.getEndDate(),
+                leaveRequest.getLeaveType(),
+                daysRequested,
                 leaveRequest.getReason(),
                 leaveRequest.getStatus(),
                 leaveRequest.getSubmittedAt()

--- a/src/main/java/com/shiftsync/shiftsync/leave/repository/LeaveRequestRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/repository/LeaveRequestRepository.java
@@ -1,0 +1,31 @@
+package com.shiftsync.shiftsync.leave.repository;
+
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.Collection;
+
+@Repository
+public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long> {
+
+    @Query("""
+            select case when count(lr) > 0 then true else false end
+            from LeaveRequest lr
+            where lr.employee.id = :employeeId
+              and lr.status in :statuses
+              and lr.startDate <= :endDate
+              and lr.endDate >= :startDate
+            """)
+    boolean existsOverlappingByEmployeeAndStatuses(
+            @Param("employeeId") Long employeeId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            @Param("statuses") Collection<LeaveStatus> statuses
+    );
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/repository/LeaveRequestRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/repository/LeaveRequestRepository.java
@@ -11,9 +11,21 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.util.Collection;
 
+/**
+ * The interface Leave request repository.
+ */
 @Repository
 public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long>, JpaSpecificationExecutor<LeaveRequest> {
 
+    /**
+     * Exists overlapping by employee and statuses boolean.
+     *
+     * @param employeeId the employee id
+     * @param startDate  the start date
+     * @param endDate    the end date
+     * @param statuses   the statuses
+     * @return the boolean
+     */
     @Query("""
             select case when count(lr) > 0 then true else false end
             from LeaveRequest lr

--- a/src/main/java/com/shiftsync/shiftsync/leave/repository/LeaveRequestRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/repository/LeaveRequestRepository.java
@@ -3,6 +3,7 @@ package com.shiftsync.shiftsync.leave.repository;
 import com.shiftsync.shiftsync.common.enums.LeaveStatus;
 import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -11,7 +12,7 @@ import java.time.LocalDate;
 import java.util.Collection;
 
 @Repository
-public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long> {
+public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long>, JpaSpecificationExecutor<LeaveRequest> {
 
     @Query("""
             select case when count(lr) > 0 then true else false end

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
@@ -5,6 +5,7 @@ import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
 import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
+import com.shiftsync.shiftsync.leave.dto.RejectLeaveRequest;
 
 /**
  * The interface Leave request service.
@@ -29,6 +30,8 @@ public interface LeaveRequestService {
      * @return the leave request response
      */
     LeaveRequestResponse approveLeaveRequest(Long actorUserId, Long leaveRequestId, ApproveLeaveRequest request);
+
+    LeaveRequestResponse rejectLeaveRequest(Long actorUserId, Long leaveRequestId, RejectLeaveRequest request);
 
     /**
      * Gets pending leave requests.

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
@@ -2,7 +2,7 @@ package com.shiftsync.shiftsync.leave.service;
 
 import com.shiftsync.shiftsync.leave.dto.ApproveLeaveRequest;
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
-import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
+import com.shiftsync.shiftsync.leave.dto.GetLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
 import com.shiftsync.shiftsync.leave.dto.RejectLeaveRequest;
@@ -51,11 +51,10 @@ public interface LeaveRequestService {
     LeaveRequestResponse cancelLeaveRequest(Long actorUserId, Long leaveRequestId);
 
     /**
-     * Gets pending leave requests.
+     * Gets leave requests.
      *
      * @param request the request
-     * @return the pending leave requests
+     * @return the leave requests
      */
-    PendingLeaveRequestPageResponse getPendingLeaveRequests(GetPendingLeaveRequestsRequest request);
+    PendingLeaveRequestPageResponse getLeaveRequests(GetLeaveRequestsRequest request);
 }
-

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
@@ -1,10 +1,30 @@
 package com.shiftsync.shiftsync.leave.service;
 
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
+import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
 
+/**
+ * The interface Leave request service.
+ */
 public interface LeaveRequestService {
 
+    /**
+     * Create leave request leave request response.
+     *
+     * @param actorUserId the actor user id
+     * @param request     the request
+     * @return the leave request response
+     */
     LeaveRequestResponse createLeaveRequest(Long actorUserId, CreateLeaveRequest request);
+
+    /**
+     * Gets pending leave requests.
+     *
+     * @param request the request
+     * @return the pending leave requests
+     */
+    PendingLeaveRequestPageResponse getPendingLeaveRequests(GetPendingLeaveRequestsRequest request);
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
@@ -31,7 +31,24 @@ public interface LeaveRequestService {
      */
     LeaveRequestResponse approveLeaveRequest(Long actorUserId, Long leaveRequestId, ApproveLeaveRequest request);
 
+    /**
+     * Reject leave request leave request response.
+     *
+     * @param actorUserId    the actor user id
+     * @param leaveRequestId the leave request id
+     * @param request        the request
+     * @return the leave request response
+     */
     LeaveRequestResponse rejectLeaveRequest(Long actorUserId, Long leaveRequestId, RejectLeaveRequest request);
+
+    /**
+     * Cancel leave request leave request response.
+     *
+     * @param actorUserId    the actor user id
+     * @param leaveRequestId the leave request id
+     * @return the leave request response
+     */
+    LeaveRequestResponse cancelLeaveRequest(Long actorUserId, Long leaveRequestId);
 
     /**
      * Gets pending leave requests.

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
@@ -1,5 +1,6 @@
 package com.shiftsync.shiftsync.leave.service;
 
+import com.shiftsync.shiftsync.leave.dto.ApproveLeaveRequest;
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
 import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
@@ -18,6 +19,16 @@ public interface LeaveRequestService {
      * @return the leave request response
      */
     LeaveRequestResponse createLeaveRequest(Long actorUserId, CreateLeaveRequest request);
+
+    /**
+     * Approve leave request leave request response.
+     *
+     * @param actorUserId    the actor user id
+     * @param leaveRequestId the leave request id
+     * @param request        the request
+     * @return the leave request response
+     */
+    LeaveRequestResponse approveLeaveRequest(Long actorUserId, Long leaveRequestId, ApproveLeaveRequest request);
 
     /**
      * Gets pending leave requests.

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
@@ -1,0 +1,10 @@
+package com.shiftsync.shiftsync.leave.service;
+
+import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
+import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+
+public interface LeaveRequestService {
+
+    LeaveRequestResponse createLeaveRequest(Long actorUserId, CreateLeaveRequest request);
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
@@ -5,14 +5,17 @@ import com.shiftsync.shiftsync.auth.repository.UserRepository;
 import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
 import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepository;
 import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.enums.NotificationType;
+import com.shiftsync.shiftsync.common.enums.OverrideSource;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.leave.dto.ApproveLeaveRequest;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
-import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
+import com.shiftsync.shiftsync.leave.dto.GetLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestResponse;
@@ -22,6 +25,8 @@ import com.shiftsync.shiftsync.leave.mapper.LeaveRequestMapper;
 import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
 import com.shiftsync.shiftsync.leave.service.LeaveRequestService;
 import com.shiftsync.shiftsync.leave.specification.LeaveRequestSpecification;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
+import com.shiftsync.shiftsync.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -42,6 +47,8 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
     private final UserRepository userRepository;
     private final LeaveRequestRepository leaveRequestRepository;
     private final AvailabilityOverrideRepository availabilityOverrideRepository;
+    private final ManagerLocationRepository managerLocationRepository;
+    private final NotificationService notificationService;
     private final LeaveRequestMapper leaveRequestMapper;
 
     @Override
@@ -62,7 +69,7 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
         );
 
         if (overlapExists) {
-            throw new InvalidStateException("Leave request overlaps with an existing pending or approved leave request");
+            throw new DuplicateResourceException("Leave request overlaps with an existing pending or approved leave request");
         }
 
         LeaveRequest leaveRequest = LeaveRequest.builder()
@@ -93,8 +100,8 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
 
         leaveRequest.setStatus(LeaveStatus.APPROVED);
         leaveRequest.setHrNote(request.hrNote());
-        leaveRequest.setApprovedBy(approver);
-        leaveRequest.setApprovedAt(LocalDateTime.now());
+        leaveRequest.setReviewedBy(approver);
+        leaveRequest.setReviewedAt(LocalDateTime.now());
 
         LeaveRequest saved = leaveRequestRepository.save(leaveRequest);
 
@@ -103,8 +110,29 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
                 .startDate(saved.getStartDate())
                 .endDate(saved.getEndDate())
                 .reason("Approved leave request " + saved.getId())
+                .source(OverrideSource.LEAVE_APPROVAL)
                 .build();
         availabilityOverrideRepository.save(override);
+
+        // FR-LEAVE-05: notify the employee of the decision
+        Long employeeUserId = saved.getEmployee().getUser().getId();
+        String approveMsg = String.format(
+                "Your %s leave request from %s to %s has been approved. HR note: %s",
+                saved.getLeaveType(), saved.getStartDate(), saved.getEndDate(), request.hrNote()
+        );
+        notificationService.notifyUser(employeeUserId, NotificationType.LEAVE_UPDATED, approveMsg, "LEAVE_REQUEST", saved.getId());
+
+        // FR-LEAVE-04: notify managers at the employee's location of potential shift impact.
+        // TODO: Week 4 — refine to filter by actual shift assignment overlap before notifying.
+        Long locationId = saved.getEmployee().getLocation().getId();
+        List<Long> managerUserIds = managerLocationRepository.findManagerUserIdsByLocationId(locationId);
+        String conflictMsg = String.format(
+                "Employee %s has approved leave from %s to %s that may affect shift coverage.",
+                saved.getEmployee().getUser().getFullName(), saved.getStartDate(), saved.getEndDate()
+        );
+        for (Long managerUserId : managerUserIds) {
+            notificationService.notifyUser(managerUserId, NotificationType.LEAVE_CONFLICT, conflictMsg, "LEAVE_REQUEST", saved.getId());
+        }
 
         return leaveRequestMapper.toResponse(saved);
     }
@@ -124,10 +152,19 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
 
         leaveRequest.setStatus(LeaveStatus.REJECTED);
         leaveRequest.setHrNote(request.hrNote());
-        leaveRequest.setApprovedBy(reviewer);
-        leaveRequest.setApprovedAt(LocalDateTime.now());
+        leaveRequest.setReviewedBy(reviewer);
+        leaveRequest.setReviewedAt(LocalDateTime.now());
 
         LeaveRequest saved = leaveRequestRepository.save(leaveRequest);
+
+        // FR-LEAVE-05: notify the employee of the decision
+        Long employeeUserId = saved.getEmployee().getUser().getId();
+        String rejectMsg = String.format(
+                "Your %s leave request from %s to %s has been rejected. HR note: %s",
+                saved.getLeaveType(), saved.getStartDate(), saved.getEndDate(), request.hrNote()
+        );
+        notificationService.notifyUser(employeeUserId, NotificationType.LEAVE_UPDATED, rejectMsg, "LEAVE_REQUEST", saved.getId());
+
         return leaveRequestMapper.toResponse(saved);
     }
 
@@ -153,7 +190,7 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
 
     @Override
     @Transactional(readOnly = true)
-    public PendingLeaveRequestPageResponse getPendingLeaveRequests(GetPendingLeaveRequestsRequest request) {
+    public PendingLeaveRequestPageResponse getLeaveRequests(GetLeaveRequestsRequest request) {
         Pageable pageable = PageRequest.of(
                 request.page(),
                 request.size(),
@@ -161,9 +198,10 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
         );
 
         Page<LeaveRequest> page = leaveRequestRepository.findAll(
-                LeaveRequestSpecification.withPendingFilters(
+                LeaveRequestSpecification.withFilters(
                         request.employeeId(),
                         request.locationId(),
+                        request.status(),
                         request.startDate(),
                         request.endDate()
                 ),
@@ -182,4 +220,3 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
         );
     }
 }
-

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -126,6 +127,26 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
         leaveRequest.setApprovedBy(reviewer);
         leaveRequest.setApprovedAt(LocalDateTime.now());
 
+        LeaveRequest saved = leaveRequestRepository.save(leaveRequest);
+        return leaveRequestMapper.toResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    public LeaveRequestResponse cancelLeaveRequest(Long actorUserId, Long leaveRequestId) {
+        LeaveRequest leaveRequest = leaveRequestRepository.findById(leaveRequestId)
+                .orElseThrow(() -> new ResourceNotFoundException("Leave request not found"));
+
+        Long ownerUserId = leaveRequest.getEmployee().getUser().getId();
+        if (!ownerUserId.equals(actorUserId)) {
+            throw new AccessDeniedException("You can only cancel your own leave request");
+        }
+
+        if (leaveRequest.getStatus() != LeaveStatus.PENDING) {
+            throw new InvalidStateException("Only pending leave requests can be cancelled");
+        }
+
+        leaveRequest.setStatus(LeaveStatus.CANCELLED);
         LeaveRequest saved = leaveRequestRepository.save(leaveRequest);
         return leaveRequestMapper.toResponse(saved);
     }

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
@@ -1,9 +1,14 @@
 package com.shiftsync.shiftsync.leave.service.impl;
 
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.auth.repository.UserRepository;
+import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
+import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepository;
 import com.shiftsync.shiftsync.common.enums.LeaveStatus;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.leave.dto.ApproveLeaveRequest;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
@@ -24,6 +29,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -31,7 +37,9 @@ import java.util.List;
 public class LeaveRequestServiceImpl implements LeaveRequestService {
 
     private final EmployeeRepository employeeRepository;
+    private final UserRepository userRepository;
     private final LeaveRequestRepository leaveRequestRepository;
+    private final AvailabilityOverrideRepository availabilityOverrideRepository;
     private final LeaveRequestMapper leaveRequestMapper;
 
     @Override
@@ -65,6 +73,37 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
                 .build();
 
         LeaveRequest saved = leaveRequestRepository.save(leaveRequest);
+        return leaveRequestMapper.toResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    public LeaveRequestResponse approveLeaveRequest(Long actorUserId, Long leaveRequestId, ApproveLeaveRequest request) {
+        User approver = userRepository.findById(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        LeaveRequest leaveRequest = leaveRequestRepository.findById(leaveRequestId)
+                .orElseThrow(() -> new ResourceNotFoundException("Leave request not found"));
+
+        if (leaveRequest.getStatus() != LeaveStatus.PENDING) {
+            throw new InvalidStateException("Only pending leave requests can be approved");
+        }
+
+        leaveRequest.setStatus(LeaveStatus.APPROVED);
+        leaveRequest.setHrNote(request.hrNote());
+        leaveRequest.setApprovedBy(approver);
+        leaveRequest.setApprovedAt(LocalDateTime.now());
+
+        LeaveRequest saved = leaveRequestRepository.save(leaveRequest);
+
+        AvailabilityOverride override = AvailabilityOverride.builder()
+                .employee(saved.getEmployee())
+                .startDate(saved.getStartDate())
+                .endDate(saved.getEndDate())
+                .reason("Approved leave request " + saved.getId())
+                .build();
+        availabilityOverrideRepository.save(override);
+
         return leaveRequestMapper.toResponse(saved);
     }
 

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
@@ -1,17 +1,26 @@
 package com.shiftsync.shiftsync.leave.service.impl;
 
 import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
+import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
+import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
 import com.shiftsync.shiftsync.leave.mapper.LeaveRequestMapper;
 import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
 import com.shiftsync.shiftsync.leave.service.LeaveRequestService;
+import com.shiftsync.shiftsync.leave.specification.LeaveRequestSpecification;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +37,10 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
     @Override
     @Transactional
     public LeaveRequestResponse createLeaveRequest(Long actorUserId, CreateLeaveRequest request) {
+        if (request.endDate().isBefore(request.startDate())) {
+            throw new BadRequestException("End date must be on or after start date");
+        }
+
         Employee employee = employeeRepository.findByUserId(actorUserId)
                 .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
 
@@ -53,6 +66,37 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
 
         LeaveRequest saved = leaveRequestRepository.save(leaveRequest);
         return leaveRequestMapper.toResponse(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PendingLeaveRequestPageResponse getPendingLeaveRequests(GetPendingLeaveRequestsRequest request) {
+        Pageable pageable = PageRequest.of(
+                request.page(),
+                request.size(),
+                Sort.by(Sort.Direction.ASC, "submittedAt")
+        );
+
+        Page<LeaveRequest> page = leaveRequestRepository.findAll(
+                LeaveRequestSpecification.withPendingFilters(
+                        request.employeeId(),
+                        request.locationId(),
+                        request.startDate(),
+                        request.endDate()
+                ),
+                pageable
+        );
+
+        List<PendingLeaveRequestResponse> content = page.getContent().stream()
+                .map(leaveRequestMapper::toPendingResponse)
+                .toList();
+
+        return new PendingLeaveRequestPageResponse(
+                content,
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.getNumber()
+        );
     }
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
@@ -1,0 +1,58 @@
+package com.shiftsync.shiftsync.leave.service.impl;
+
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
+import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
+import com.shiftsync.shiftsync.leave.mapper.LeaveRequestMapper;
+import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
+import com.shiftsync.shiftsync.leave.service.LeaveRequestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LeaveRequestServiceImpl implements LeaveRequestService {
+
+    private final EmployeeRepository employeeRepository;
+    private final LeaveRequestRepository leaveRequestRepository;
+    private final LeaveRequestMapper leaveRequestMapper;
+
+    @Override
+    @Transactional
+    public LeaveRequestResponse createLeaveRequest(Long actorUserId, CreateLeaveRequest request) {
+        Employee employee = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
+
+        boolean overlapExists = leaveRequestRepository.existsOverlappingByEmployeeAndStatuses(
+                employee.getId(),
+                request.startDate(),
+                request.endDate(),
+                List.of(LeaveStatus.PENDING, LeaveStatus.APPROVED)
+        );
+
+        if (overlapExists) {
+            throw new InvalidStateException("Leave request overlaps with an existing pending or approved leave request");
+        }
+
+        LeaveRequest leaveRequest = LeaveRequest.builder()
+                .employee(employee)
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .leaveType(request.leaveType())
+                .reason(request.reason())
+                .status(LeaveStatus.PENDING)
+                .build();
+
+        LeaveRequest saved = leaveRequestRepository.save(leaveRequest);
+        return leaveRequestMapper.toResponse(saved);
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/impl/LeaveRequestServiceImpl.java
@@ -16,6 +16,7 @@ import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.dto.RejectLeaveRequest;
 import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
 import com.shiftsync.shiftsync.leave.mapper.LeaveRequestMapper;
 import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
@@ -104,6 +105,28 @@ public class LeaveRequestServiceImpl implements LeaveRequestService {
                 .build();
         availabilityOverrideRepository.save(override);
 
+        return leaveRequestMapper.toResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    public LeaveRequestResponse rejectLeaveRequest(Long actorUserId, Long leaveRequestId, RejectLeaveRequest request) {
+        User reviewer = userRepository.findById(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        LeaveRequest leaveRequest = leaveRequestRepository.findById(leaveRequestId)
+                .orElseThrow(() -> new ResourceNotFoundException("Leave request not found"));
+
+        if (leaveRequest.getStatus() != LeaveStatus.PENDING) {
+            throw new InvalidStateException("Only pending leave requests can be rejected");
+        }
+
+        leaveRequest.setStatus(LeaveStatus.REJECTED);
+        leaveRequest.setHrNote(request.hrNote());
+        leaveRequest.setApprovedBy(reviewer);
+        leaveRequest.setApprovedAt(LocalDateTime.now());
+
+        LeaveRequest saved = leaveRequestRepository.save(leaveRequest);
         return leaveRequestMapper.toResponse(saved);
     }
 

--- a/src/main/java/com/shiftsync/shiftsync/leave/specification/LeaveRequestSpecification.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/specification/LeaveRequestSpecification.java
@@ -11,20 +11,23 @@ public final class LeaveRequestSpecification {
     private LeaveRequestSpecification() {
     }
 
-    public static Specification<LeaveRequest> withPendingFilters(
+    public static Specification<LeaveRequest> withFilters(
             Long employeeId,
             Long locationId,
+            LeaveStatus status,
             LocalDate startDate,
             LocalDate endDate
     ) {
-        return Specification.where(hasStatus())
+        return Specification.where(hasStatus(status))
                 .and(hasEmployeeId(employeeId))
                 .and(hasLocationId(locationId))
                 .and(overlapsDateRange(startDate, endDate));
     }
 
-    private static Specification<LeaveRequest> hasStatus() {
-        return (root, _, cb) -> cb.equal(root.get("status"), LeaveStatus.PENDING);
+    private static Specification<LeaveRequest> hasStatus(LeaveStatus status) {
+        return (root, _, cb) -> status == null
+                ? cb.conjunction()
+                : cb.equal(root.get("status"), status);
     }
 
     private static Specification<LeaveRequest> hasEmployeeId(Long employeeId) {
@@ -57,4 +60,3 @@ public final class LeaveRequestSpecification {
         };
     }
 }
-

--- a/src/main/java/com/shiftsync/shiftsync/leave/specification/LeaveRequestSpecification.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/specification/LeaveRequestSpecification.java
@@ -1,0 +1,60 @@
+package com.shiftsync.shiftsync.leave.specification;
+
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDate;
+
+public final class LeaveRequestSpecification {
+
+    private LeaveRequestSpecification() {
+    }
+
+    public static Specification<LeaveRequest> withPendingFilters(
+            Long employeeId,
+            Long locationId,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        return Specification.where(hasStatus())
+                .and(hasEmployeeId(employeeId))
+                .and(hasLocationId(locationId))
+                .and(overlapsDateRange(startDate, endDate));
+    }
+
+    private static Specification<LeaveRequest> hasStatus() {
+        return (root, _, cb) -> cb.equal(root.get("status"), LeaveStatus.PENDING);
+    }
+
+    private static Specification<LeaveRequest> hasEmployeeId(Long employeeId) {
+        return (root, _, cb) -> employeeId == null
+                ? cb.conjunction()
+                : cb.equal(root.get("employee").get("id"), employeeId);
+    }
+
+    private static Specification<LeaveRequest> hasLocationId(Long locationId) {
+        return (root, _, cb) -> locationId == null
+                ? cb.conjunction()
+                : cb.equal(root.get("employee").get("location").get("id"), locationId);
+    }
+
+    private static Specification<LeaveRequest> overlapsDateRange(LocalDate startDate, LocalDate endDate) {
+        return (root, _, cb) -> {
+            if (startDate == null && endDate == null) {
+                return cb.conjunction();
+            }
+            if (startDate == null) {
+                return cb.lessThanOrEqualTo(root.get("startDate"), endDate);
+            }
+            if (endDate == null) {
+                return cb.greaterThanOrEqualTo(root.get("endDate"), startDate);
+            }
+            return cb.and(
+                    cb.lessThanOrEqualTo(root.get("startDate"), endDate),
+                    cb.greaterThanOrEqualTo(root.get("endDate"), startDate)
+            );
+        };
+    }
+}
+

--- a/src/main/java/com/shiftsync/shiftsync/location/repository/ManagerLocationRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/location/repository/ManagerLocationRepository.java
@@ -23,6 +23,9 @@ public interface ManagerLocationRepository extends JpaRepository<ManagerLocation
     @Query("select ml.location.id from ManagerLocation ml where ml.manager.id = :managerEmployeeId")
     List<Long> findLocationIdsByManagerEmployeeId(Long managerEmployeeId);
 
+    @Query("select ml.manager.user.id from ManagerLocation ml where ml.location.id = :locationId")
+    List<Long> findManagerUserIdsByLocationId(Long locationId);
+
     /**
      * Exists by manager id and location id boolean.
      *

--- a/src/main/java/com/shiftsync/shiftsync/notification/entity/Notification.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/entity/Notification.java
@@ -1,0 +1,66 @@
+package com.shiftsync.shiftsync.notification.entity;
+
+import com.shiftsync.shiftsync.common.enums.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "?::notification_type")
+    @Column(name = "type", nullable = false)
+    private NotificationType type;
+
+    @Column(name = "message", nullable = false)
+    private String message;
+
+    @Column(name = "entity_type")
+    private String entityType;
+
+    @Column(name = "entity_id")
+    private Long entityId;
+
+    @Column(name = "read", nullable = false)
+    private boolean read;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        read = false;
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/repository/NotificationRepository.java
@@ -1,0 +1,9 @@
+package com.shiftsync.shiftsync.notification.repository;
+
+import com.shiftsync.shiftsync.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/shiftsync/shiftsync/notification/service/NotificationService.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/service/NotificationService.java
@@ -1,0 +1,8 @@
+package com.shiftsync.shiftsync.notification.service;
+
+import com.shiftsync.shiftsync.common.enums.NotificationType;
+
+public interface NotificationService {
+
+    void notifyUser(Long userId, NotificationType type, String message, String entityType, Long entityId);
+}

--- a/src/main/java/com/shiftsync/shiftsync/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,29 @@
+package com.shiftsync.shiftsync.notification.service.impl;
+
+import com.shiftsync.shiftsync.common.enums.NotificationType;
+import com.shiftsync.shiftsync.notification.entity.Notification;
+import com.shiftsync.shiftsync.notification.repository.NotificationRepository;
+import com.shiftsync.shiftsync.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Override
+    @Transactional
+    public void notifyUser(Long userId, NotificationType type, String message, String entityType, Long entityId) {
+        Notification notification = Notification.builder()
+                .userId(userId)
+                .type(type)
+                .message(message)
+                .entityType(entityType)
+                .entityId(entityId)
+                .build();
+        notificationRepository.save(notification);
+    }
+}

--- a/src/main/resources/db/changelog/changes/004-leave-request-updates.xml
+++ b/src/main/resources/db/changelog/changes/004-leave-request-updates.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <!-- Rename approved_by/approved_at to reviewed_by/reviewed_at on leave_requests.
+         These fields record who reviewed the request (approve OR reject), so 'approved'
+         is misleading on rejected requests. -->
+    <changeSet id="004-001-rename-reviewed-columns-in-leave-requests" author="shiftsync">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="leave_requests" columnName="approved_by"/>
+        </preConditions>
+        <renameColumn tableName="leave_requests"
+                      oldColumnName="approved_by"
+                      newColumnName="reviewed_by"
+                      columnDataType="bigint"/>
+        <renameColumn tableName="leave_requests"
+                      oldColumnName="approved_at"
+                      newColumnName="reviewed_at"
+                      columnDataType="timestamp"/>
+        <rollback>
+            <renameColumn tableName="leave_requests"
+                          oldColumnName="reviewed_by"
+                          newColumnName="approved_by"
+                          columnDataType="bigint"/>
+            <renameColumn tableName="leave_requests"
+                          oldColumnName="reviewed_at"
+                          newColumnName="approved_at"
+                          columnDataType="timestamp"/>
+        </rollback>
+    </changeSet>
+
+    <!-- Add source column to availability_overrides to distinguish leave-sourced blocks
+         from employee-declared unavailability (needed for US-AVAIL-02 delete guard). -->
+    <changeSet id="004-002-add-source-to-availability-overrides" author="shiftsync">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="availability_overrides" columnName="source"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="availability_overrides">
+            <column name="source" type="varchar(50)" defaultValue="LEAVE_APPROVAL">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <rollback>
+            <dropColumn tableName="availability_overrides" columnName="source"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -9,5 +9,6 @@
     <include file="db/changelog/changes/001-initial-schema.xml"/>
     <include file="db/changelog/changes/002-add-employees-notification-enabled.xml"/>
     <include file="db/changelog/changes/003-add-users-must-reset-password.xml"/>
+    <include file="db/changelog/changes/004-leave-request-updates.xml"/>
 
 </databaseChangeLog>

--- a/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
@@ -3,13 +3,14 @@ package com.shiftsync.shiftsync.leave.controller;
 import com.shiftsync.shiftsync.common.enums.LeaveStatus;
 import com.shiftsync.shiftsync.common.enums.LeaveType;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
 import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
 import com.shiftsync.shiftsync.config.security.JwtService;
 import com.shiftsync.shiftsync.config.security.SecurityConfig;
-import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
+import com.shiftsync.shiftsync.leave.dto.GetLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestResponse;
@@ -173,7 +174,7 @@ class LeaveRequestControllerWebMvcTest {
     @WithMockUser(username = "5", roles = "EMPLOYEE")
     void createLeaveRequest_OverlappingDates_ReturnsConflict() throws Exception {
         when(leaveRequestService.createLeaveRequest(eq(5L), any()))
-                .thenThrow(new InvalidStateException("Leave request overlaps with an existing pending or approved leave request"));
+                .thenThrow(new DuplicateResourceException("Leave request overlaps with an existing pending or approved leave request"));
 
         String body = """
                 {
@@ -191,21 +192,21 @@ class LeaveRequestControllerWebMvcTest {
     }
 
     @Test
-    void getPendingLeaveRequests_WithoutToken_ReturnsUnauthorized() throws Exception {
+    void getLeaveRequests_WithoutToken_ReturnsUnauthorized() throws Exception {
         mockMvc.perform(get("/api/v1/leave-requests"))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     @WithMockUser(username = "5", roles = "EMPLOYEE")
-    void getPendingLeaveRequests_WrongRole_ReturnsForbidden() throws Exception {
+    void getLeaveRequests_WrongRole_ReturnsForbidden() throws Exception {
         mockMvc.perform(get("/api/v1/leave-requests"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     @WithMockUser(username = "1", roles = "HR_ADMIN")
-    void getPendingLeaveRequests_Success_ReturnsOk() throws Exception {
+    void getLeaveRequests_Success_ReturnsOk() throws Exception {
         PendingLeaveRequestResponse item = new PendingLeaveRequestResponse(
                 100L,
                 20L,
@@ -226,7 +227,7 @@ class LeaveRequestControllerWebMvcTest {
                 0
         );
 
-        when(leaveRequestService.getPendingLeaveRequests(any(GetPendingLeaveRequestsRequest.class)))
+        when(leaveRequestService.getLeaveRequests(any(GetLeaveRequestsRequest.class)))
                 .thenReturn(pageResponse);
 
         mockMvc.perform(get("/api/v1/leave-requests")
@@ -241,9 +242,10 @@ class LeaveRequestControllerWebMvcTest {
                 .andExpect(jsonPath("$.content[0].employeeName").value("Employee One"))
                 .andExpect(jsonPath("$.content[0].daysRequested").value(3));
 
-        verify(leaveRequestService).getPendingLeaveRequests(argThat(req ->
+        verify(leaveRequestService).getLeaveRequests(argThat(req ->
                 req.employeeId().equals(20L)
                         && req.locationId().equals(3L)
+                        && req.status() == null
                         && req.startDate().equals(LocalDate.of(2099, 1, 1))
                         && req.endDate().equals(LocalDate.of(2099, 1, 31))
                         && req.page() == 0

--- a/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
@@ -1,0 +1,181 @@
+package com.shiftsync.shiftsync.leave.controller;
+
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.enums.LeaveType;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.service.LeaveRequestService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LeaveRequestController.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, AuthenticationHelper.class})
+class LeaveRequestControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LeaveRequestService leaveRequestService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Test
+    void createLeaveRequest_WithoutToken_ReturnsUnauthorized() throws Exception {
+        String body = """
+                {
+                  "startDate": "2099-01-01",
+                  "endDate": "2099-01-03",
+                  "leaveType": "ANNUAL",
+                  "reason": "Family event"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/leave-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void createLeaveRequest_WrongRole_ReturnsForbidden() throws Exception {
+        String body = """
+                {
+                  "startDate": "2099-01-01",
+                  "endDate": "2099-01-03",
+                  "leaveType": "ANNUAL",
+                  "reason": "Family event"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/leave-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void createLeaveRequest_Success_ReturnsCreated() throws Exception {
+        LeaveRequestResponse response = new LeaveRequestResponse(
+                100L,
+                20L,
+                LocalDate.of(2099, 1, 1),
+                LocalDate.of(2099, 1, 3),
+                LeaveType.ANNUAL,
+                "Family event",
+                LeaveStatus.PENDING,
+                LocalDateTime.of(2098, 12, 1, 10, 0)
+        );
+        when(leaveRequestService.createLeaveRequest(eq(5L), any())).thenReturn(response);
+
+        String body = """
+                {
+                  "startDate": "2099-01-01",
+                  "endDate": "2099-01-03",
+                  "leaveType": "ANNUAL",
+                  "reason": "Family event"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/leave-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(100))
+                .andExpect(jsonPath("$.status").value("PENDING"));
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void createLeaveRequest_MissingRequiredFields_ReturnsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/v1/leave-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void createLeaveRequest_StartDateInPast_ReturnsBadRequest() throws Exception {
+        String body = """
+                {
+                  "startDate": "2020-01-01",
+                  "endDate": "2099-01-03",
+                  "leaveType": "ANNUAL"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/leave-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void createLeaveRequest_EndDateBeforeStartDate_ReturnsBadRequest() throws Exception {
+        String body = """
+                {
+                  "startDate": "2099-01-10",
+                  "endDate": "2099-01-03",
+                  "leaveType": "ANNUAL"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/leave-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void createLeaveRequest_OverlappingDates_ReturnsConflict() throws Exception {
+        when(leaveRequestService.createLeaveRequest(eq(5L), any()))
+                .thenThrow(new InvalidStateException("Leave request overlaps with an existing pending or approved leave request"));
+
+        String body = """
+                {
+                  "startDate": "2099-01-01",
+                  "endDate": "2099-01-03",
+                  "leaveType": "ANNUAL"
+                }
+                """;
+
+        mockMvc.perform(post("/api/v1/leave-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Leave request overlaps with an existing pending or approved leave request"));
+    }
+}
+

--- a/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
@@ -33,6 +33,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -372,6 +373,62 @@ class LeaveRequestControllerWebMvcTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(100))
                 .andExpect(jsonPath("$.status").value("REJECTED"));
+    }
+
+    @Test
+    void cancelLeaveRequest_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(delete("/api/v1/leave-requests/100"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void cancelLeaveRequest_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(delete("/api/v1/leave-requests/100"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void cancelLeaveRequest_NotPending_ReturnsConflict() throws Exception {
+        when(leaveRequestService.cancelLeaveRequest(eq(5L), eq(100L)))
+                .thenThrow(new InvalidStateException("Only pending leave requests can be cancelled"));
+
+        mockMvc.perform(delete("/api/v1/leave-requests/100"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Only pending leave requests can be cancelled"));
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void cancelLeaveRequest_OtherEmployee_ReturnsForbidden() throws Exception {
+        when(leaveRequestService.cancelLeaveRequest(eq(5L), eq(100L)))
+                .thenThrow(new org.springframework.security.access.AccessDeniedException("You can only cancel your own leave request"));
+
+        mockMvc.perform(delete("/api/v1/leave-requests/100"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("You can only cancel your own leave request"));
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void cancelLeaveRequest_Success_ReturnsOk() throws Exception {
+        LeaveRequestResponse response = new LeaveRequestResponse(
+                100L,
+                20L,
+                LocalDate.of(2099, 1, 1),
+                LocalDate.of(2099, 1, 3),
+                LeaveType.ANNUAL,
+                "Family event",
+                LeaveStatus.CANCELLED,
+                LocalDateTime.of(2098, 12, 1, 10, 0)
+        );
+        when(leaveRequestService.cancelLeaveRequest(eq(5L), eq(100L))).thenReturn(response);
+
+        mockMvc.perform(delete("/api/v1/leave-requests/100"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(100))
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
@@ -311,5 +311,67 @@ class LeaveRequestControllerWebMvcTest {
                 .andExpect(jsonPath("$.id").value(100))
                 .andExpect(jsonPath("$.status").value("APPROVED"));
     }
+
+    @Test
+    void rejectLeaveRequest_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/v1/leave-requests/100/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"hrNote\":\"Rejected\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void rejectLeaveRequest_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/v1/leave-requests/100/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"hrNote\":\"Rejected\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void rejectLeaveRequest_MissingHrNote_ReturnsBadRequest() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/v1/leave-requests/100/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"hrNote\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void rejectLeaveRequest_NotPending_ReturnsConflict() throws Exception {
+        when(leaveRequestService.rejectLeaveRequest(eq(1L), eq(100L), any()))
+                .thenThrow(new InvalidStateException("Only pending leave requests can be rejected"));
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/v1/leave-requests/100/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"hrNote\":\"Rejected\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Only pending leave requests can be rejected"));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void rejectLeaveRequest_Success_ReturnsOk() throws Exception {
+        LeaveRequestResponse response = new LeaveRequestResponse(
+                100L,
+                20L,
+                LocalDate.of(2099, 1, 1),
+                LocalDate.of(2099, 1, 3),
+                LeaveType.ANNUAL,
+                "Family event",
+                LeaveStatus.REJECTED,
+                LocalDateTime.of(2098, 12, 1, 10, 0)
+        );
+        when(leaveRequestService.rejectLeaveRequest(eq(1L), eq(100L), any())).thenReturn(response);
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/v1/leave-requests/100/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"hrNote\":\"Rejected\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(100))
+                .andExpect(jsonPath("$.status").value("REJECTED"));
+    }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
@@ -2,13 +2,17 @@ package com.shiftsync.shiftsync.leave.controller;
 
 import com.shiftsync.shiftsync.common.enums.LeaveStatus;
 import com.shiftsync.shiftsync.common.enums.LeaveType;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
 import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
 import com.shiftsync.shiftsync.config.security.JwtService;
 import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
+import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.service.LeaveRequestService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,10 +26,14 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -143,6 +151,9 @@ class LeaveRequestControllerWebMvcTest {
     @Test
     @WithMockUser(username = "5", roles = "EMPLOYEE")
     void createLeaveRequest_EndDateBeforeStartDate_ReturnsBadRequest() throws Exception {
+        when(leaveRequestService.createLeaveRequest(eq(5L), any()))
+                .thenThrow(new BadRequestException("End date must be on or after start date"));
+
         String body = """
                 {
                   "startDate": "2099-01-10",
@@ -176,6 +187,67 @@ class LeaveRequestControllerWebMvcTest {
                         .content(body))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.message").value("Leave request overlaps with an existing pending or approved leave request"));
+    }
+
+    @Test
+    void getPendingLeaveRequests_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/leave-requests"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void getPendingLeaveRequests_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/leave-requests"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void getPendingLeaveRequests_Success_ReturnsOk() throws Exception {
+        PendingLeaveRequestResponse item = new PendingLeaveRequestResponse(
+                100L,
+                20L,
+                "Employee One",
+                "Kitchen",
+                LocalDate.of(2099, 1, 1),
+                LocalDate.of(2099, 1, 3),
+                LeaveType.ANNUAL,
+                3,
+                "Family event",
+                LeaveStatus.PENDING,
+                LocalDateTime.of(2098, 12, 1, 10, 0)
+        );
+        PendingLeaveRequestPageResponse pageResponse = new PendingLeaveRequestPageResponse(
+                List.of(item),
+                1,
+                1,
+                0
+        );
+
+        when(leaveRequestService.getPendingLeaveRequests(any(GetPendingLeaveRequestsRequest.class)))
+                .thenReturn(pageResponse);
+
+        mockMvc.perform(get("/api/v1/leave-requests")
+                        .param("employeeId", "20")
+                        .param("locationId", "3")
+                        .param("startDate", "2099-01-01")
+                        .param("endDate", "2099-01-31")
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.content[0].employeeName").value("Employee One"))
+                .andExpect(jsonPath("$.content[0].daysRequested").value(3));
+
+        verify(leaveRequestService).getPendingLeaveRequests(argThat(req ->
+                req.employeeId().equals(20L)
+                        && req.locationId().equals(3L)
+                        && req.startDate().equals(LocalDate.of(2099, 1, 1))
+                        && req.endDate().equals(LocalDate.of(2099, 1, 31))
+                        && req.page() == 0
+                        && req.size() == 10
+        ));
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java
@@ -249,5 +249,67 @@ class LeaveRequestControllerWebMvcTest {
                         && req.size() == 10
         ));
     }
+
+    @Test
+    void approveLeaveRequest_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/v1/leave-requests/100/approve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"hrNote\":\"Approved\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "5", roles = "EMPLOYEE")
+    void approveLeaveRequest_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/v1/leave-requests/100/approve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"hrNote\":\"Approved\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void approveLeaveRequest_MissingHrNote_ReturnsBadRequest() throws Exception {
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/v1/leave-requests/100/approve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"hrNote\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void approveLeaveRequest_NotPending_ReturnsConflict() throws Exception {
+        when(leaveRequestService.approveLeaveRequest(eq(1L), eq(100L), any()))
+                .thenThrow(new InvalidStateException("Only pending leave requests can be approved"));
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/v1/leave-requests/100/approve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"hrNote\":\"Approved\"}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Only pending leave requests can be approved"));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void approveLeaveRequest_Success_ReturnsOk() throws Exception {
+        LeaveRequestResponse response = new LeaveRequestResponse(
+                100L,
+                20L,
+                LocalDate.of(2099, 1, 1),
+                LocalDate.of(2099, 1, 3),
+                LeaveType.ANNUAL,
+                "Family event",
+                LeaveStatus.APPROVED,
+                LocalDateTime.of(2098, 12, 1, 10, 0)
+        );
+        when(leaveRequestService.approveLeaveRequest(eq(1L), eq(100L), any())).thenReturn(response);
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/v1/leave-requests/100/approve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"hrNote\":\"Approved\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(100))
+                .andExpect(jsonPath("$.status").value("APPROVED"));
+    }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
@@ -4,26 +4,38 @@ import com.shiftsync.shiftsync.auth.entity.User;
 import com.shiftsync.shiftsync.common.enums.LeaveStatus;
 import com.shiftsync.shiftsync.common.enums.LeaveType;
 import com.shiftsync.shiftsync.common.enums.UserRole;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.department.entity.Department;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
+import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
+import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
 import com.shiftsync.shiftsync.leave.mapper.LeaveRequestMapper;
 import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
 import com.shiftsync.shiftsync.leave.service.impl.LeaveRequestServiceImpl;
+import com.shiftsync.shiftsync.location.entity.Location;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,6 +68,9 @@ class LeaveRequestServiceImplTest {
 
     @BeforeEach
     void setUp() {
+        Department department = Department.builder().id(2L).name("Kitchen").build();
+        Location location = Location.builder().id(3L).name("Airport Branch").address("Accra").maxHeadcountPerShift(10).active(true).build();
+
         User user = User.builder()
                 .id(5L)
                 .email("employee@shiftsync.com")
@@ -72,6 +87,8 @@ class LeaveRequestServiceImplTest {
                 .hireDate(LocalDate.of(2026, 1, 1))
                 .active(true)
                 .notificationEnabled(true)
+                .department(department)
+                .location(location)
                 .build();
 
         request = new CreateLeaveRequest(
@@ -139,6 +156,59 @@ class LeaveRequestServiceImplTest {
         assertThatThrownBy(() -> leaveRequestService.createLeaveRequest(5L, request))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("Employee profile not found");
+    }
+
+    @Test
+    void createLeaveRequest_EndDateBeforeStartDate_ThrowsBadRequest() {
+        CreateLeaveRequest invalidRequest = new CreateLeaveRequest(
+                LocalDate.now().plusDays(3),
+                LocalDate.now().plusDays(1),
+                LeaveType.ANNUAL,
+                "Family event"
+        );
+
+        assertThatThrownBy(() -> leaveRequestService.createLeaveRequest(5L, invalidRequest))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("End date must be on or after start date");
+    }
+
+    @Test
+    void getPendingLeaveRequests_ReturnsPagedResponse() {
+        GetPendingLeaveRequestsRequest getRequest = new GetPendingLeaveRequestsRequest(
+                20L,
+                3L,
+                LocalDate.of(2099, 1, 1),
+                LocalDate.of(2099, 1, 31),
+                0,
+                10
+        );
+
+        PendingLeaveRequestResponse pendingResponse = new PendingLeaveRequestResponse(
+                100L,
+                20L,
+                "Employee One",
+                "Kitchen",
+                LocalDate.of(2099, 1, 1),
+                LocalDate.of(2099, 1, 3),
+                LeaveType.ANNUAL,
+                3,
+                "Family event",
+                LeaveStatus.PENDING,
+                LocalDateTime.of(2098, 12, 1, 10, 0)
+        );
+
+        Page<LeaveRequest> page = new PageImpl<>(List.of(leaveRequest), PageRequest.of(0, 10), 1);
+
+        when(leaveRequestRepository.findAll(org.mockito.ArgumentMatchers.<Specification<LeaveRequest>>any(), any(Pageable.class))).thenReturn(page);
+        when(leaveRequestMapper.toPendingResponse(leaveRequest)).thenReturn(pendingResponse);
+
+        PendingLeaveRequestPageResponse result = leaveRequestService.getPendingLeaveRequests(getRequest);
+
+        assertThat(result.totalElements()).isEqualTo(1);
+        assertThat(result.totalPages()).isEqualTo(1);
+        assertThat(result.currentPage()).isEqualTo(0);
+        assertThat(result.content()).hasSize(1);
+        assertThat(result.content().getFirst().employeeName()).isEqualTo("Employee One");
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
@@ -1,0 +1,144 @@
+package com.shiftsync.shiftsync.leave.service;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.enums.LeaveType;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
+import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
+import com.shiftsync.shiftsync.leave.mapper.LeaveRequestMapper;
+import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
+import com.shiftsync.shiftsync.leave.service.impl.LeaveRequestServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LeaveRequestServiceImplTest {
+
+    @Mock
+    private EmployeeRepository employeeRepository;
+
+    @Mock
+    private LeaveRequestRepository leaveRequestRepository;
+
+    @Mock
+    private LeaveRequestMapper leaveRequestMapper;
+
+    @InjectMocks
+    private LeaveRequestServiceImpl leaveRequestService;
+
+    private Employee employee;
+    private CreateLeaveRequest request;
+    private LeaveRequest leaveRequest;
+    private LeaveRequestResponse response;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .id(5L)
+                .email("employee@shiftsync.com")
+                .fullName("Employee One")
+                .passwordHash("hash")
+                .role(UserRole.EMPLOYEE)
+                .build();
+
+        employee = Employee.builder()
+                .id(20L)
+                .user(user)
+                .employmentType(com.shiftsync.shiftsync.common.enums.EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("40.00"))
+                .hireDate(LocalDate.of(2026, 1, 1))
+                .active(true)
+                .notificationEnabled(true)
+                .build();
+
+        request = new CreateLeaveRequest(
+                LocalDate.now().plusDays(1),
+                LocalDate.now().plusDays(3),
+                LeaveType.ANNUAL,
+                "Family event"
+        );
+
+        leaveRequest = LeaveRequest.builder()
+                .id(100L)
+                .employee(employee)
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .leaveType(request.leaveType())
+                .reason(request.reason())
+                .status(LeaveStatus.PENDING)
+                .submittedAt(LocalDateTime.now())
+                .build();
+
+        response = new LeaveRequestResponse(
+                100L,
+                20L,
+                request.startDate(),
+                request.endDate(),
+                LeaveType.ANNUAL,
+                "Family event",
+                LeaveStatus.PENDING,
+                LocalDateTime.now()
+        );
+    }
+
+    @Test
+    void createLeaveRequest_Success() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
+        when(leaveRequestRepository.existsOverlappingByEmployeeAndStatuses(eq(20L), eq(request.startDate()), eq(request.endDate()), any()))
+                .thenReturn(false);
+        when(leaveRequestRepository.save(any(LeaveRequest.class))).thenReturn(leaveRequest);
+        when(leaveRequestMapper.toResponse(leaveRequest)).thenReturn(response);
+
+        LeaveRequestResponse created = leaveRequestService.createLeaveRequest(5L, request);
+
+        assertThat(created.id()).isEqualTo(100L);
+        assertThat(created.status()).isEqualTo(LeaveStatus.PENDING);
+        verify(leaveRequestRepository).save(any(LeaveRequest.class));
+    }
+
+    @Test
+    void createLeaveRequest_OverlappingDates_ThrowsConflict() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(employee));
+        when(leaveRequestRepository.existsOverlappingByEmployeeAndStatuses(eq(20L), eq(request.startDate()), eq(request.endDate()), any()))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> leaveRequestService.createLeaveRequest(5L, request))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Leave request overlaps with an existing pending or approved leave request");
+
+        verify(leaveRequestRepository, never()).save(any(LeaveRequest.class));
+    }
+
+    @Test
+    void createLeaveRequest_EmployeeNotFound_ThrowsNotFound() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> leaveRequestService.createLeaveRequest(5L, request))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Employee profile not found");
+    }
+}
+

--- a/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
@@ -1,12 +1,16 @@
 package com.shiftsync.shiftsync.leave.service;
 
 import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.auth.repository.UserRepository;
+import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
+import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepository;
 import com.shiftsync.shiftsync.common.enums.LeaveStatus;
 import com.shiftsync.shiftsync.common.enums.LeaveType;
 import com.shiftsync.shiftsync.common.enums.UserRole;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.leave.dto.ApproveLeaveRequest;
 import com.shiftsync.shiftsync.department.entity.Department;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
@@ -53,7 +57,13 @@ class LeaveRequestServiceImplTest {
     private EmployeeRepository employeeRepository;
 
     @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private LeaveRequestRepository leaveRequestRepository;
+
+    @Mock
+    private AvailabilityOverrideRepository availabilityOverrideRepository;
 
     @Mock
     private LeaveRequestMapper leaveRequestMapper;
@@ -65,6 +75,7 @@ class LeaveRequestServiceImplTest {
     private CreateLeaveRequest request;
     private LeaveRequest leaveRequest;
     private LeaveRequestResponse response;
+    private User hrAdmin;
 
     @BeforeEach
     void setUp() {
@@ -77,6 +88,14 @@ class LeaveRequestServiceImplTest {
                 .fullName("Employee One")
                 .passwordHash("hash")
                 .role(UserRole.EMPLOYEE)
+                .build();
+
+        hrAdmin = User.builder()
+                .id(1L)
+                .email("hr@shiftsync.com")
+                .fullName("HR Admin")
+                .passwordHash("hash")
+                .role(UserRole.HR_ADMIN)
                 .build();
 
         employee = Employee.builder()
@@ -209,6 +228,48 @@ class LeaveRequestServiceImplTest {
         assertThat(result.currentPage()).isEqualTo(0);
         assertThat(result.content()).hasSize(1);
         assertThat(result.content().getFirst().employeeName()).isEqualTo("Employee One");
+    }
+
+    @Test
+    void approveLeaveRequest_Success() {
+        ApproveLeaveRequest approveRequest = new ApproveLeaveRequest("Approved for annual leave");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(hrAdmin));
+        when(leaveRequestRepository.findById(100L)).thenReturn(Optional.of(leaveRequest));
+        when(leaveRequestRepository.save(any(LeaveRequest.class))).thenReturn(leaveRequest);
+        when(leaveRequestMapper.toResponse(leaveRequest)).thenReturn(response);
+
+        LeaveRequestResponse approved = leaveRequestService.approveLeaveRequest(1L, 100L, approveRequest);
+
+        assertThat(approved.id()).isEqualTo(100L);
+        verify(availabilityOverrideRepository).save(any(AvailabilityOverride.class));
+    }
+
+    @Test
+    void approveLeaveRequest_NotPending_ThrowsConflict() {
+        ApproveLeaveRequest approveRequest = new ApproveLeaveRequest("Approved for annual leave");
+        leaveRequest.setStatus(LeaveStatus.APPROVED);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(hrAdmin));
+        when(leaveRequestRepository.findById(100L)).thenReturn(Optional.of(leaveRequest));
+
+        assertThatThrownBy(() -> leaveRequestService.approveLeaveRequest(1L, 100L, approveRequest))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Only pending leave requests can be approved");
+
+        verify(availabilityOverrideRepository, never()).save(any(AvailabilityOverride.class));
+    }
+
+    @Test
+    void approveLeaveRequest_LeaveNotFound_ThrowsNotFound() {
+        ApproveLeaveRequest approveRequest = new ApproveLeaveRequest("Approved for annual leave");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(hrAdmin));
+        when(leaveRequestRepository.findById(100L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> leaveRequestService.approveLeaveRequest(1L, 100L, approveRequest))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Leave request not found");
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
@@ -36,6 +36,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -313,6 +314,47 @@ class LeaveRequestServiceImplTest {
         assertThatThrownBy(() -> leaveRequestService.rejectLeaveRequest(1L, 100L, rejectRequest))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("Leave request not found");
+    }
+
+    @Test
+    void cancelLeaveRequest_Success() {
+        when(leaveRequestRepository.findById(100L)).thenReturn(Optional.of(leaveRequest));
+        when(leaveRequestRepository.save(any(LeaveRequest.class))).thenReturn(leaveRequest);
+        when(leaveRequestMapper.toResponse(leaveRequest)).thenReturn(response);
+
+        LeaveRequestResponse cancelled = leaveRequestService.cancelLeaveRequest(5L, 100L);
+
+        assertThat(cancelled.id()).isEqualTo(100L);
+        verify(availabilityOverrideRepository, never()).save(any(AvailabilityOverride.class));
+    }
+
+    @Test
+    void cancelLeaveRequest_Approved_ThrowsConflict() {
+        leaveRequest.setStatus(LeaveStatus.APPROVED);
+        when(leaveRequestRepository.findById(100L)).thenReturn(Optional.of(leaveRequest));
+
+        assertThatThrownBy(() -> leaveRequestService.cancelLeaveRequest(5L, 100L))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Only pending leave requests can be cancelled");
+    }
+
+    @Test
+    void cancelLeaveRequest_Rejected_ThrowsConflict() {
+        leaveRequest.setStatus(LeaveStatus.REJECTED);
+        when(leaveRequestRepository.findById(100L)).thenReturn(Optional.of(leaveRequest));
+
+        assertThatThrownBy(() -> leaveRequestService.cancelLeaveRequest(5L, 100L))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Only pending leave requests can be cancelled");
+    }
+
+    @Test
+    void cancelLeaveRequest_DifferentEmployee_ThrowsForbidden() {
+        when(leaveRequestRepository.findById(100L)).thenReturn(Optional.of(leaveRequest));
+
+        assertThatThrownBy(() -> leaveRequestService.cancelLeaveRequest(9L, 100L))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("You can only cancel your own leave request");
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
@@ -6,8 +6,10 @@ import com.shiftsync.shiftsync.availability.entity.AvailabilityOverride;
 import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepository;
 import com.shiftsync.shiftsync.common.enums.LeaveStatus;
 import com.shiftsync.shiftsync.common.enums.LeaveType;
+import com.shiftsync.shiftsync.common.enums.NotificationType;
 import com.shiftsync.shiftsync.common.enums.UserRole;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.DuplicateResourceException;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.leave.dto.ApproveLeaveRequest;
@@ -15,7 +17,7 @@ import com.shiftsync.shiftsync.department.entity.Department;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
-import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
+import com.shiftsync.shiftsync.leave.dto.GetLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestResponse;
@@ -25,6 +27,8 @@ import com.shiftsync.shiftsync.leave.mapper.LeaveRequestMapper;
 import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
 import com.shiftsync.shiftsync.leave.service.impl.LeaveRequestServiceImpl;
 import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
+import com.shiftsync.shiftsync.notification.service.NotificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,6 +70,12 @@ class LeaveRequestServiceImplTest {
 
     @Mock
     private AvailabilityOverrideRepository availabilityOverrideRepository;
+
+    @Mock
+    private ManagerLocationRepository managerLocationRepository;
+
+    @Mock
+    private NotificationService notificationService;
 
     @Mock
     private LeaveRequestMapper leaveRequestMapper;
@@ -164,7 +174,7 @@ class LeaveRequestServiceImplTest {
                 .thenReturn(true);
 
         assertThatThrownBy(() -> leaveRequestService.createLeaveRequest(5L, request))
-                .isInstanceOf(InvalidStateException.class)
+                .isInstanceOf(DuplicateResourceException.class)
                 .hasMessage("Leave request overlaps with an existing pending or approved leave request");
 
         verify(leaveRequestRepository, never()).save(any(LeaveRequest.class));
@@ -194,10 +204,11 @@ class LeaveRequestServiceImplTest {
     }
 
     @Test
-    void getPendingLeaveRequests_ReturnsPagedResponse() {
-        GetPendingLeaveRequestsRequest getRequest = new GetPendingLeaveRequestsRequest(
+    void getLeaveRequests_ReturnsPagedResponse() {
+        GetLeaveRequestsRequest getRequest = new GetLeaveRequestsRequest(
                 20L,
                 3L,
+                null,
                 LocalDate.of(2099, 1, 1),
                 LocalDate.of(2099, 1, 31),
                 0,
@@ -223,7 +234,7 @@ class LeaveRequestServiceImplTest {
         when(leaveRequestRepository.findAll(org.mockito.ArgumentMatchers.<Specification<LeaveRequest>>any(), any(Pageable.class))).thenReturn(page);
         when(leaveRequestMapper.toPendingResponse(leaveRequest)).thenReturn(pendingResponse);
 
-        PendingLeaveRequestPageResponse result = leaveRequestService.getPendingLeaveRequests(getRequest);
+        PendingLeaveRequestPageResponse result = leaveRequestService.getLeaveRequests(getRequest);
 
         assertThat(result.totalElements()).isEqualTo(1);
         assertThat(result.totalPages()).isEqualTo(1);
@@ -240,11 +251,13 @@ class LeaveRequestServiceImplTest {
         when(leaveRequestRepository.findById(100L)).thenReturn(Optional.of(leaveRequest));
         when(leaveRequestRepository.save(any(LeaveRequest.class))).thenReturn(leaveRequest);
         when(leaveRequestMapper.toResponse(leaveRequest)).thenReturn(response);
+        when(managerLocationRepository.findManagerUserIdsByLocationId(3L)).thenReturn(List.of());
 
         LeaveRequestResponse approved = leaveRequestService.approveLeaveRequest(1L, 100L, approveRequest);
 
         assertThat(approved.id()).isEqualTo(100L);
         verify(availabilityOverrideRepository).save(any(AvailabilityOverride.class));
+        verify(notificationService).notifyUser(eq(5L), eq(NotificationType.LEAVE_UPDATED), any(), eq("LEAVE_REQUEST"), eq(100L));
     }
 
     @Test
@@ -287,6 +300,7 @@ class LeaveRequestServiceImplTest {
 
         assertThat(rejected.id()).isEqualTo(100L);
         verify(availabilityOverrideRepository, never()).save(any(AvailabilityOverride.class));
+        verify(notificationService).notifyUser(eq(5L), eq(NotificationType.LEAVE_UPDATED), any(), eq("LEAVE_REQUEST"), eq(100L));
     }
 
     @Test
@@ -357,4 +371,3 @@ class LeaveRequestServiceImplTest {
                 .hasMessage("You can only cancel your own leave request");
     }
 }
-

--- a/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
@@ -19,6 +19,7 @@ import com.shiftsync.shiftsync.leave.dto.GetPendingLeaveRequestsRequest;
 import com.shiftsync.shiftsync.leave.dto.LeaveRequestResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestPageResponse;
 import com.shiftsync.shiftsync.leave.dto.PendingLeaveRequestResponse;
+import com.shiftsync.shiftsync.leave.dto.RejectLeaveRequest;
 import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
 import com.shiftsync.shiftsync.leave.mapper.LeaveRequestMapper;
 import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
@@ -268,6 +269,48 @@ class LeaveRequestServiceImplTest {
         when(leaveRequestRepository.findById(100L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> leaveRequestService.approveLeaveRequest(1L, 100L, approveRequest))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Leave request not found");
+    }
+
+    @Test
+    void rejectLeaveRequest_Success() {
+        RejectLeaveRequest rejectRequest = new RejectLeaveRequest("Insufficient staffing");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(hrAdmin));
+        when(leaveRequestRepository.findById(100L)).thenReturn(Optional.of(leaveRequest));
+        when(leaveRequestRepository.save(any(LeaveRequest.class))).thenReturn(leaveRequest);
+        when(leaveRequestMapper.toResponse(leaveRequest)).thenReturn(response);
+
+        LeaveRequestResponse rejected = leaveRequestService.rejectLeaveRequest(1L, 100L, rejectRequest);
+
+        assertThat(rejected.id()).isEqualTo(100L);
+        verify(availabilityOverrideRepository, never()).save(any(AvailabilityOverride.class));
+    }
+
+    @Test
+    void rejectLeaveRequest_NotPending_ThrowsConflict() {
+        RejectLeaveRequest rejectRequest = new RejectLeaveRequest("Insufficient staffing");
+        leaveRequest.setStatus(LeaveStatus.APPROVED);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(hrAdmin));
+        when(leaveRequestRepository.findById(100L)).thenReturn(Optional.of(leaveRequest));
+
+        assertThatThrownBy(() -> leaveRequestService.rejectLeaveRequest(1L, 100L, rejectRequest))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Only pending leave requests can be rejected");
+
+        verify(availabilityOverrideRepository, never()).save(any(AvailabilityOverride.class));
+    }
+
+    @Test
+    void rejectLeaveRequest_LeaveNotFound_ThrowsNotFound() {
+        RejectLeaveRequest rejectRequest = new RejectLeaveRequest("Insufficient staffing");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(hrAdmin));
+        when(leaveRequestRepository.findById(100L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> leaveRequestService.rejectLeaveRequest(1L, 100L, rejectRequest))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("Leave request not found");
     }


### PR DESCRIPTION
## What
Implements **Epic 5: Leave Request Management** end-to-end:

- **US-LEAVE-01**: employee submits leave request
  - `POST /api/v1/leave-requests`
  - Validates required fields and date rules (`endDate >= startDate`)
  - Rejects overlap with existing `PENDING`/`APPROVED` leave using `409`
  - Creates leave with initial `PENDING` status

- **US-LEAVE-02**: HR Admin views pending leave requests
  - `GET /api/v1/leave-requests`
  - Supports filters (`employeeId`, `locationId`, `startDate`, `endDate`)
  - Supports pagination (`page`, `size`)
  - Default sorting by oldest submissions first (`submittedAt ASC`)

- **US-LEAVE-03**: HR Admin approves leave
  - `PATCH /api/v1/leave-requests/{id}/approve`
  - Requires non-empty `hrNote`
  - Enforces valid transition (`PENDING -> APPROVED`)
  - On approval, creates `AvailabilityOverride` for the leave date range

- **US-LEAVE-04**: HR Admin rejects leave
  - `PATCH /api/v1/leave-requests/{id}/reject`
  - Requires non-empty `hrNote`
  - Enforces valid transition (`PENDING -> REJECTED`)

- **US-LEAVE-05**: employee cancels own request
  - `DELETE /api/v1/leave-requests/{id}`
  - Ownership enforced (cannot cancel another employee’s request)
  - Only `PENDING` requests can be cancelled
  - Sets status to `CANCELLED`

## Why
Implements the leave lifecycle and review workflow required by:

- `US-LEAVE-01`: employee leave submission with validation and conflict prevention
- `US-LEAVE-02`: HR visibility into pending requests for operational decisions
- `US-LEAVE-03`: formal approval flow with HR audit note and availability blocking
- `US-LEAVE-04`: formal rejection flow with HR audit note
- `US-LEAVE-05`: self-service cancellation before HR finalization

This provides a complete request -> review -> resolution flow and keeps leave data consistent with availability planning.

## How to test
1. **Submit leave request (employee)**
   - Call `POST /api/v1/leave-requests` with valid future date range -> `201`
   - Submit with `endDate < startDate` -> `400`
   - Submit overlapping existing `PENDING/APPROVED` leave -> `409`

2. **List pending requests (HR Admin)**
   - Call `GET /api/v1/leave-requests?page=0&size=10` -> `200`
   - Add filters (`employeeId`, `locationId`, `startDate`, `endDate`) and verify filtered results
   - Confirm oldest pending requests appear first

3. **Approve request (HR Admin)**
   - Call `PATCH /api/v1/leave-requests/{id}/approve` with non-empty `hrNote` -> `200`
   - Verify status changes to `APPROVED`
   - Verify availability override is created for the approved date range

4. **Reject request (HR Admin)**
   - Call `PATCH /api/v1/leave-requests/{id}/reject` with non-empty `hrNote` -> `200`
   - Verify status changes to `REJECTED`

5. **Cancel request (employee)**
   - Call `DELETE /api/v1/leave-requests/{id}` on own `PENDING` request -> `200`
   - Cancel non-`PENDING` request -> `409`
   - Cancel another employee’s request -> `403`

### Automated tests
Test files:

- `src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java`
- `src/test/java/com/shiftsync/shiftsync/leave/controller/LeaveRequestControllerWebMvcTest.java`

Targeted test command:

```powershell
.\mvnw.cmd "-Dtest=LeaveRequestServiceImplTest,LeaveRequestControllerWebMvcTest" test
```

## Notes
- **Versioning deviation**: endpoints use `/api/v1/...` while stories often show `/api/...`. This is an intentional API versioning decision applied consistently.
- **Availability alignment**: approving leave writes an `AvailabilityOverride` to keep leave decisions consistent with availability data.
- **State safety**: all approve/reject/cancel actions enforce valid state transitions and return conflict on invalid transitions.
