### PR TITLE
feat: shift scheduling lifecycle and swap management

### DIFF
--- a/src/main/java/com/shiftsync/shiftsync/config/CacheConfig.java
+++ b/src/main/java/com/shiftsync/shiftsync/config/CacheConfig.java
@@ -1,0 +1,19 @@
+package com.shiftsync.shiftsync.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String LOCATION_SHIFTS = "location-shifts";
+
+    @Bean
+    CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager(LOCATION_SHIFTS);
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/controller/EmployeeShiftController.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/controller/EmployeeShiftController.java
@@ -1,0 +1,58 @@
+package com.shiftsync.shiftsync.shift.controller;
+
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.shift.dto.EmployeeShiftResponse;
+import com.shiftsync.shiftsync.shift.service.ShiftService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/employees/me/shifts")
+@RequiredArgsConstructor
+@Tag(name = "Employee Shifts", description = "Employee shift viewing endpoints")
+public class EmployeeShiftController {
+
+    private final ShiftService shiftService;
+    private final AuthenticationHelper authenticationHelper;
+
+    @GetMapping
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    @Operation(
+            summary = "View my upcoming shifts",
+            description = "Returns assigned shifts in the given date range. Defaults to today through today + 28 days. Add ?include=cancelled to include cancelled shifts."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Shifts returned"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Employee profile not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<EmployeeShiftResponse>> getMyShifts(
+            Authentication authentication,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) String include
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        LocalDate fromDate = from != null ? from : LocalDate.now();
+        LocalDate toDate = to != null ? to : LocalDate.now().plusDays(28);
+        boolean includeCancelled = "cancelled".equalsIgnoreCase(include);
+        return ResponseEntity.ok(shiftService.getMyShifts(actorUserId, fromDate, toDate, includeCancelled));
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/controller/LocationShiftController.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/controller/LocationShiftController.java
@@ -54,8 +54,9 @@ public class LocationShiftController {
             @RequestParam(defaultValue = "20") int size
     ) {
         Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        shiftService.verifyManagerLocationAccess(actorUserId, locationId);
         LocalDate fromDate = from != null ? from : LocalDate.now();
         LocalDate toDate = to != null ? to : LocalDate.now().plusDays(6);
-        return ResponseEntity.ok(shiftService.getLocationShifts(actorUserId, locationId, fromDate, toDate, departmentId, page, size));
+        return ResponseEntity.ok(shiftService.getLocationShifts(locationId, fromDate, toDate, departmentId, page, size));
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/controller/LocationShiftController.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/controller/LocationShiftController.java
@@ -1,0 +1,61 @@
+package com.shiftsync.shiftsync.shift.controller;
+
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.shift.dto.LocationShiftPageResponse;
+import com.shiftsync.shiftsync.shift.service.ShiftService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/v1/locations")
+@RequiredArgsConstructor
+@Tag(name = "Location Shifts", description = "Location shift schedule endpoints")
+public class LocationShiftController {
+
+    private final ShiftService shiftService;
+    private final AuthenticationHelper authenticationHelper;
+
+    @GetMapping("/{locationId}/shifts")
+    @PreAuthorize("hasAnyRole('MANAGER', 'HR_ADMIN')")
+    @Operation(
+            summary = "View location shift schedule",
+            description = "Returns a paginated shift schedule for a location. Managers must be assigned to the location. Response is cached and invalidated on any shift change."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Schedule returned", content = @Content(schema = @Schema(implementation = LocationShiftPageResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Manager not assigned to the location", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "User not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LocationShiftPageResponse> getLocationShifts(
+            Authentication authentication,
+            @PathVariable Long locationId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) Long departmentId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        LocalDate fromDate = from != null ? from : LocalDate.now();
+        LocalDate toDate = to != null ? to : LocalDate.now().plusDays(6);
+        return ResponseEntity.ok(shiftService.getLocationShifts(actorUserId, locationId, fromDate, toDate, departmentId, page, size));
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftAssignmentController.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftAssignmentController.java
@@ -17,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -61,6 +62,28 @@ public class ShiftAssignmentController {
         }
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @DeleteMapping("/{shiftId}/assignments/{employeeId}")
+    @PreAuthorize("hasRole('MANAGER')")
+    @Operation(
+            summary = "Remove employee from shift",
+            description = "Removes an employee assignment from a shift and notifies the employee."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Assignment removed"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Shift or assignment not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> removeAssignment(
+            Authentication authentication,
+            @PathVariable Long shiftId,
+            @PathVariable Long employeeId
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        shiftAssignmentService.removeAssignment(actorUserId, shiftId, employeeId);
+        return ResponseEntity.noContent().build();
     }
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftController.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftController.java
@@ -1,0 +1,60 @@
+package com.shiftsync.shiftsync.shift.controller;
+
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
+import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
+import com.shiftsync.shiftsync.shift.service.ShiftService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@RestController
+@RequestMapping("/api/v1/shifts")
+@RequiredArgsConstructor
+@Tag(name = "Shifts", description = "Shift management endpoints")
+public class ShiftController {
+
+    private final ShiftService shiftService;
+    private final AuthenticationHelper authenticationHelper;
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('MANAGER', 'HR_ADMIN')")
+    @Operation(
+            summary = "Create a shift",
+            description = "Creates a new shift for a location and department. Managers must be assigned to the specified location."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Shift created", content = @Content(schema = @Schema(implementation = ShiftResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid input or end time not after start time", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Manager not assigned to the location", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Location or department not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<ShiftResponse> createShift(
+            Authentication authentication,
+            @Valid @RequestBody CreateShiftRequest request
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        ShiftResponse response = shiftService.createShift(actorUserId, request);
+        return ResponseEntity
+                .created(ServletUriComponentsBuilder.fromCurrentRequest()
+                        .path("/{id}")
+                        .buildAndExpand(response.id())
+                        .toUri())
+                .body(response);
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftController.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftController.java
@@ -16,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -56,5 +58,27 @@ public class ShiftController {
                         .buildAndExpand(response.id())
                         .toUri())
                 .body(response);
+    }
+
+    @PatchMapping("/{shiftId}/cancel")
+    @PreAuthorize("hasAnyRole('MANAGER', 'HR_ADMIN')")
+    @Operation(
+            summary = "Cancel a shift",
+            description = "Cancels a shift and notifies all assigned employees. Managers must be assigned to the shift's location."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Shift cancelled"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Manager not assigned to the location", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Shift not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Shift already cancelled", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> cancelShift(
+            Authentication authentication,
+            @PathVariable Long shiftId
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        shiftService.cancelShift(actorUserId, shiftId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapController.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapController.java
@@ -1,0 +1,103 @@
+package com.shiftsync.shiftsync.shift.controller;
+
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.shift.dto.RejectSwapRequest;
+import com.shiftsync.shiftsync.shift.dto.ShiftSwapRequest;
+import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
+import com.shiftsync.shiftsync.shift.service.ShiftSwapService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/shift-swaps")
+@RequiredArgsConstructor
+@Tag(name = "Shift Swaps", description = "Shift swap request and approval endpoints")
+public class ShiftSwapController {
+
+    private final ShiftSwapService shiftSwapService;
+    private final AuthenticationHelper authenticationHelper;
+
+    @PostMapping
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    @Operation(
+            summary = "Request a shift swap",
+            description = "Allows an employee to propose a shift swap with a colleague. Provides myShiftAssignmentId and targetEmployeeId; optionally targetShiftAssignmentId for a two-way swap."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Swap request created", content = @Content(schema = @Schema(implementation = ShiftSwapResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Requester not assigned to the referenced shift", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Assignment or employee not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<ShiftSwapResponse> requestSwap(
+            Authentication authentication,
+            @Valid @RequestBody ShiftSwapRequest request
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(shiftSwapService.requestSwap(actorUserId, request));
+    }
+
+    @PatchMapping("/{swapId}/approve")
+    @PreAuthorize("hasAnyRole('MANAGER', 'HR_ADMIN')")
+    @Operation(
+            summary = "Approve a shift swap",
+            description = "Atomically reassigns both shifts within a single transaction. Re-runs conflict checks before approval; returns 409 if a conflict is detected."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Swap approved"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Swap request not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Swap not pending, or conflict detected", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> approveSwap(
+            Authentication authentication,
+            @PathVariable Long swapId
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        shiftSwapService.approveSwap(actorUserId, swapId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{swapId}/reject")
+    @PreAuthorize("hasAnyRole('MANAGER', 'HR_ADMIN')")
+    @Operation(
+            summary = "Reject a shift swap",
+            description = "Rejects the swap request and optionally records a manager note. Returns 409 if not in PENDING_MANAGER_APPROVAL status."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Swap rejected"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Swap request not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Swap is not pending approval", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> rejectSwap(
+            Authentication authentication,
+            @PathVariable Long swapId,
+            @RequestBody(required = false) RejectSwapRequest body
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        shiftSwapService.rejectSwap(actorUserId, swapId, body != null ? body.managerNote() : null);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/AssigneeInfo.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/AssigneeInfo.java
@@ -1,0 +1,7 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+public record AssigneeInfo(
+        String fullName,
+        String employmentType
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/CreateShiftRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/CreateShiftRequest.java
@@ -1,0 +1,33 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record CreateShiftRequest(
+        @NotNull(message = "locationId is required")
+        Long locationId,
+
+        @NotNull(message = "departmentId is required")
+        Long departmentId,
+
+        @NotNull(message = "date is required")
+        @FutureOrPresent(message = "Shift date cannot be in the past")
+        LocalDate date,
+
+        @NotNull(message = "startTime is required")
+        LocalTime startTime,
+
+        @NotNull(message = "endTime is required")
+        LocalTime endTime,
+
+        String requiredSkill,
+
+        @NotNull(message = "minimumHeadcount is required")
+        @Min(value = 1, message = "minimumHeadcount must be at least 1")
+        Integer minimumHeadcount
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/EmployeeShiftResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/EmployeeShiftResponse.java
@@ -1,0 +1,17 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record EmployeeShiftResponse(
+        Long shiftId,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String locationName,
+        String departmentName,
+        String status,
+        List<String> assignedColleagues
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/LocationShiftPageResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/LocationShiftPageResponse.java
@@ -1,0 +1,11 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+import java.util.List;
+
+public record LocationShiftPageResponse(
+        List<LocationShiftResponse> content,
+        int totalElements,
+        int totalPages,
+        int currentPage
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/LocationShiftResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/LocationShiftResponse.java
@@ -1,0 +1,20 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+import com.shiftsync.shiftsync.shift.entity.StaffingStatus;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record LocationShiftResponse(
+        Long shiftId,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String departmentName,
+        Integer minimumHeadcount,
+        Integer assignedCount,
+        StaffingStatus staffingStatus,
+        List<AssigneeInfo> assignedEmployees
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/RejectSwapRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/RejectSwapRequest.java
@@ -1,0 +1,3 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+public record RejectSwapRequest(String managerNote) {}

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/ShiftResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/ShiftResponse.java
@@ -1,0 +1,20 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record ShiftResponse(
+        Long id,
+        Long locationId,
+        String locationName,
+        Long departmentId,
+        String departmentName,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String requiredSkill,
+        Integer minimumHeadcount,
+        String status,
+        Integer assignedCount
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/ShiftSwapRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/ShiftSwapRequest.java
@@ -1,0 +1,10 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ShiftSwapRequest(
+        @NotNull Long myShiftAssignmentId,
+        @NotNull Long targetEmployeeId,
+        Long targetShiftAssignmentId,
+        String reason
+) {}

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/ShiftSwapResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/ShiftSwapResponse.java
@@ -1,0 +1,23 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record ShiftSwapResponse(
+        Long id,
+        Long requesterId,
+        String requesterName,
+        LocalDate requesterShiftDate,
+        LocalTime requesterStartTime,
+        LocalTime requesterEndTime,
+        Long targetEmployeeId,
+        String targetEmployeeName,
+        LocalDate targetShiftDate,
+        LocalTime targetStartTime,
+        LocalTime targetEndTime,
+        String status,
+        String reason,
+        String managerNote,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/shiftsync/shiftsync/shift/entity/ShiftSwap.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/entity/ShiftSwap.java
@@ -1,0 +1,90 @@
+package com.shiftsync.shiftsync.shift.entity;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnTransformer;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "shift_swaps")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ShiftSwap {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requester_id", nullable = false)
+    private Employee requester;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requester_assignment_id", nullable = false)
+    private ShiftAssignment requesterAssignment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_employee_id", nullable = false)
+    private Employee targetEmployee;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_assignment_id")
+    private ShiftAssignment targetAssignment;
+
+    @Column(name = "reason")
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "?::shift_swap_status")
+    @Column(name = "status", nullable = false)
+    private ShiftSwapStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewed_by")
+    private User reviewedBy;
+
+    @Column(name = "manager_note")
+    private String managerNote;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (status == null) {
+            status = ShiftSwapStatus.PENDING_MANAGER_APPROVAL;
+        }
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/entity/ShiftSwapStatus.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/entity/ShiftSwapStatus.java
@@ -1,0 +1,7 @@
+package com.shiftsync.shiftsync.shift.entity;
+
+public enum ShiftSwapStatus {
+    PENDING_MANAGER_APPROVAL,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/entity/StaffingStatus.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/entity/StaffingStatus.java
@@ -1,0 +1,7 @@
+package com.shiftsync.shiftsync.shift.entity;
+
+public enum StaffingStatus {
+    UNDERSTAFFED,
+    FULLY_STAFFED,
+    OVERSTAFFED
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
@@ -110,4 +110,21 @@ public interface ShiftAssignmentRepository extends JpaRepository<ShiftAssignment
             where sa.shift.id in :shiftIds
             """)
     List<ShiftAssignment> findAssignmentsByShiftIds(@Param("shiftIds") Collection<Long> shiftIds);
+
+    @Query("""
+            select (count(sa) > 0)
+            from ShiftAssignment sa
+            where sa.employee.id = :employeeId
+              and sa.shift.id not in :excludedShiftIds
+              and sa.shift.shiftDate = :shiftDate
+              and sa.shift.startTime < :endTime
+              and sa.shift.endTime > :startTime
+            """)
+    boolean existsConflictExcluding(
+            @Param("employeeId") Long employeeId,
+            @Param("excludedShiftIds") Collection<Long> excludedShiftIds,
+            @Param("shiftDate") LocalDate shiftDate,
+            @Param("startTime") LocalTime startTime,
+            @Param("endTime") LocalTime endTime
+    );
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
@@ -1,6 +1,7 @@
 package com.shiftsync.shiftsync.shift.repository;
 
 import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
+import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -66,5 +68,37 @@ public interface ShiftAssignmentRepository extends JpaRepository<ShiftAssignment
             @Param("employeeId") Long employeeId,
             @Param("weekStart") LocalDate weekStart,
             @Param("weekEnd") LocalDate weekEnd
+    );
+
+    @Query("""
+            select sa
+            from ShiftAssignment sa
+            join fetch sa.shift s
+            join fetch s.location
+            join fetch s.department
+            where sa.employee.id = :employeeId
+              and s.shiftDate >= :from
+              and s.shiftDate <= :to
+              and s.status in :statuses
+            order by s.shiftDate asc, s.startTime asc
+            """)
+    List<ShiftAssignment> findByEmployeeInRange(
+            @Param("employeeId") Long employeeId,
+            @Param("from") LocalDate from,
+            @Param("to") LocalDate to,
+            @Param("statuses") Collection<ShiftStatus> statuses
+    );
+
+    @Query("""
+            select sa
+            from ShiftAssignment sa
+            join fetch sa.employee e
+            join fetch e.user u
+            where sa.shift.id in :shiftIds
+              and sa.employee.id <> :excludeEmployeeId
+            """)
+    List<ShiftAssignment> findColleaguesByShiftIds(
+            @Param("shiftIds") Collection<Long> shiftIds,
+            @Param("excludeEmployeeId") Long excludeEmployeeId
     );
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The interface Shift assignment repository.
@@ -38,6 +39,8 @@ public interface ShiftAssignmentRepository extends JpaRepository<ShiftAssignment
             @Param("startTime") LocalTime startTime,
             @Param("endTime") LocalTime endTime
     );
+
+    Optional<ShiftAssignment> findByShiftIdAndEmployeeId(Long shiftId, Long employeeId);
 
     /**
      * Returns all assignments for an employee within a given week range, with shift eagerly joined.

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
@@ -101,4 +101,13 @@ public interface ShiftAssignmentRepository extends JpaRepository<ShiftAssignment
             @Param("shiftIds") Collection<Long> shiftIds,
             @Param("excludeEmployeeId") Long excludeEmployeeId
     );
+
+    @Query("""
+            select sa
+            from ShiftAssignment sa
+            join fetch sa.employee e
+            join fetch e.user u
+            where sa.shift.id in :shiftIds
+            """)
+    List<ShiftAssignment> findAssignmentsByShiftIds(@Param("shiftIds") Collection<Long> shiftIds);
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
@@ -2,7 +2,13 @@ package com.shiftsync.shiftsync.shift.repository;
 
 import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 
 /**
  * The interface Shift assignment repository.
@@ -10,13 +16,43 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ShiftAssignmentRepository extends JpaRepository<ShiftAssignment, Long> {
 
-    /**
-     * Exists by shift id and employee id boolean.
-     *
-     * @param shiftId    the shift id
-     * @param employeeId the employee id
-     * @return the boolean
-     */
     boolean existsByShiftIdAndEmployeeId(Long shiftId, Long employeeId);
-}
 
+    /**
+     * Returns true if the employee has an overlapping shift assignment on the same date,
+     * excluding the given shift itself.
+     */
+    @Query("""
+            select (count(sa) > 0)
+            from ShiftAssignment sa
+            where sa.employee.id = :employeeId
+              and sa.shift.id <> :shiftId
+              and sa.shift.shiftDate = :shiftDate
+              and sa.shift.startTime < :endTime
+              and sa.shift.endTime > :startTime
+            """)
+    boolean existsOverlappingAssignment(
+            @Param("employeeId") Long employeeId,
+            @Param("shiftId") Long shiftId,
+            @Param("shiftDate") LocalDate shiftDate,
+            @Param("startTime") LocalTime startTime,
+            @Param("endTime") LocalTime endTime
+    );
+
+    /**
+     * Returns all assignments for an employee within a given week range, with shift eagerly joined.
+     */
+    @Query("""
+            select sa
+            from ShiftAssignment sa
+            join fetch sa.shift s
+            where sa.employee.id = :employeeId
+              and s.shiftDate >= :weekStart
+              and s.shiftDate <= :weekEnd
+            """)
+    List<ShiftAssignment> findByEmployeeInWeek(
+            @Param("employeeId") Long employeeId,
+            @Param("weekStart") LocalDate weekStart,
+            @Param("weekEnd") LocalDate weekEnd
+    );
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
@@ -42,6 +42,15 @@ public interface ShiftAssignmentRepository extends JpaRepository<ShiftAssignment
 
     Optional<ShiftAssignment> findByShiftIdAndEmployeeId(Long shiftId, Long employeeId);
 
+    @Query("""
+            select sa
+            from ShiftAssignment sa
+            join fetch sa.employee e
+            join fetch e.user u
+            where sa.shift.id = :shiftId
+            """)
+    List<ShiftAssignment> findByShiftId(@Param("shiftId") Long shiftId);
+
     /**
      * Returns all assignments for an employee within a given week range, with shift eagerly joined.
      */

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftRepository.java
@@ -1,19 +1,26 @@
 package com.shiftsync.shiftsync.shift.repository;
 
 import com.shiftsync.shiftsync.shift.entity.Shift;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The interface Shift repository.
  */
 @Repository
 public interface ShiftRepository extends JpaRepository<Shift, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Shift s where s.id = :id")
+    Optional<Shift> findByIdForUpdate(@Param("id") Long id);
 
     @Query("""
             select s

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftRepository.java
@@ -2,12 +2,32 @@ package com.shiftsync.shiftsync.shift.repository;
 
 import com.shiftsync.shiftsync.shift.entity.Shift;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 /**
  * The interface Shift repository.
  */
 @Repository
 public interface ShiftRepository extends JpaRepository<Shift, Long> {
-}
 
+    @Query("""
+            select s
+            from Shift s
+            join fetch s.location
+            join fetch s.department
+            where s.location.id = :locationId
+              and s.shiftDate >= :from
+              and s.shiftDate <= :to
+            order by s.shiftDate asc, s.startTime asc
+            """)
+    List<Shift> findByLocationInRange(
+            @Param("locationId") Long locationId,
+            @Param("from") LocalDate from,
+            @Param("to") LocalDate to
+    );
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftSwapRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftSwapRepository.java
@@ -1,0 +1,28 @@
+package com.shiftsync.shiftsync.shift.repository;
+
+import com.shiftsync.shiftsync.shift.entity.ShiftSwap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ShiftSwapRepository extends JpaRepository<ShiftSwap, Long> {
+
+    @Query("""
+            select sw
+            from ShiftSwap sw
+            join fetch sw.requester req
+            join fetch req.user reqUser
+            join fetch sw.requesterAssignment ra
+            join fetch ra.shift raShift
+            join fetch sw.targetEmployee te
+            join fetch te.user teUser
+            left join fetch sw.targetAssignment ta
+            left join fetch ta.shift taShift
+            where sw.id = :id
+            """)
+    Optional<ShiftSwap> findByIdWithDetails(@Param("id") Long id);
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentService.java
@@ -18,5 +18,14 @@ public interface ShiftAssignmentService {
      * @return the assign employee response
      */
     AssignEmployeeResponse assignEmployee(Long actorUserId, Long shiftId, AssignEmployeeRequest request, boolean override);
+
+    /**
+     * Removes an employee from a shift and notifies the employee.
+     *
+     * @param actorUserId the manager's user ID
+     * @param shiftId     the shift ID
+     * @param employeeId  the employee ID to remove
+     */
+    void removeAssignment(Long actorUserId, Long shiftId, Long employeeId);
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
@@ -13,4 +13,12 @@ public interface ShiftService {
      * @return the created shift response
      */
     ShiftResponse createShift(Long actorUserId, CreateShiftRequest request);
+
+    /**
+     * Cancels a shift and notifies all assigned employees.
+     *
+     * @param actorUserId the ID of the authenticated user performing the cancel
+     * @param shiftId     the shift to cancel
+     */
+    void cancelShift(Long actorUserId, Long shiftId);
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
@@ -1,0 +1,16 @@
+package com.shiftsync.shiftsync.shift.service;
+
+import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
+import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
+
+public interface ShiftService {
+
+    /**
+     * Creates a new shift for a given location and department.
+     *
+     * @param actorUserId the ID of the authenticated user creating the shift
+     * @param request     the shift creation request
+     * @return the created shift response
+     */
+    ShiftResponse createShift(Long actorUserId, CreateShiftRequest request);
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
@@ -2,6 +2,7 @@ package com.shiftsync.shiftsync.shift.service;
 
 import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
 import com.shiftsync.shiftsync.shift.dto.EmployeeShiftResponse;
+import com.shiftsync.shiftsync.shift.dto.LocationShiftPageResponse;
 import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
 
 import java.time.LocalDate;
@@ -36,4 +37,18 @@ public interface ShiftService {
      * @return list of shift responses with colleague info
      */
     List<EmployeeShiftResponse> getMyShifts(Long actorUserId, LocalDate from, LocalDate to, boolean includeCancelled);
+
+    /**
+     * Returns a paginated shift schedule for a location, with staffing status per shift.
+     *
+     * @param actorUserId  the authenticated user's ID
+     * @param locationId   the location to query
+     * @param from         start of the date range (inclusive)
+     * @param to           end of the date range (inclusive)
+     * @param departmentId optional department filter
+     * @param page         zero-based page number
+     * @param size         page size
+     * @return paginated location shift schedule
+     */
+    LocationShiftPageResponse getLocationShifts(Long actorUserId, Long locationId, LocalDate from, LocalDate to, Long departmentId, int page, int size);
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
@@ -1,7 +1,11 @@
 package com.shiftsync.shiftsync.shift.service;
 
 import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
+import com.shiftsync.shiftsync.shift.dto.EmployeeShiftResponse;
 import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface ShiftService {
 
@@ -21,4 +25,15 @@ public interface ShiftService {
      * @param shiftId     the shift to cancel
      */
     void cancelShift(Long actorUserId, Long shiftId);
+
+    /**
+     * Returns the authenticated employee's assigned shifts within the given date range.
+     *
+     * @param actorUserId      the employee's user ID
+     * @param from             start of the date range (inclusive)
+     * @param to               end of the date range (inclusive)
+     * @param includeCancelled whether to include cancelled shifts
+     * @return list of shift responses with colleague info
+     */
+    List<EmployeeShiftResponse> getMyShifts(Long actorUserId, LocalDate from, LocalDate to, boolean includeCancelled);
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
@@ -39,9 +39,15 @@ public interface ShiftService {
     List<EmployeeShiftResponse> getMyShifts(Long actorUserId, LocalDate from, LocalDate to, boolean includeCancelled);
 
     /**
+     * Throws AccessDeniedException if a MANAGER user is not assigned to the given location.
+     * HR_ADMIN users always pass. Call this before the cached getLocationShifts so the guard
+     * is never skipped by a cache hit.
+     */
+    void verifyManagerLocationAccess(Long actorUserId, Long locationId);
+
+    /**
      * Returns a paginated shift schedule for a location, with staffing status per shift.
      *
-     * @param actorUserId  the authenticated user's ID
      * @param locationId   the location to query
      * @param from         start of the date range (inclusive)
      * @param to           end of the date range (inclusive)
@@ -50,5 +56,5 @@ public interface ShiftService {
      * @param size         page size
      * @return paginated location shift schedule
      */
-    LocationShiftPageResponse getLocationShifts(Long actorUserId, Long locationId, LocalDate from, LocalDate to, Long departmentId, int page, int size);
+    LocationShiftPageResponse getLocationShifts(Long locationId, LocalDate from, LocalDate to, Long departmentId, int page, int size);
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftSwapService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftSwapService.java
@@ -1,0 +1,13 @@
+package com.shiftsync.shiftsync.shift.service;
+
+import com.shiftsync.shiftsync.shift.dto.ShiftSwapRequest;
+import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
+
+public interface ShiftSwapService {
+
+    ShiftSwapResponse requestSwap(Long actorUserId, ShiftSwapRequest request);
+
+    void approveSwap(Long actorUserId, Long swapId);
+
+    void rejectSwap(Long actorUserId, Long swapId, String managerNote);
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
@@ -148,6 +148,39 @@ public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
         return new AssignEmployeeResponse("ASSIGNED", List.of(), "Employee assigned successfully", saved.getId());
     }
 
+    @Override
+    @Transactional
+    public void removeAssignment(Long actorUserId, Long shiftId, Long employeeId) {
+        Employee manager = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
+
+        Shift shift = shiftRepository.findById(shiftId)
+                .orElseThrow(() -> new ResourceNotFoundException("Shift not found"));
+
+        List<Long> assignedLocations = managerLocationRepository.findLocationIdsByManagerEmployeeId(manager.getId());
+        if (!assignedLocations.contains(shift.getLocation().getId())) {
+            throw new AccessDeniedException("You are not assigned to this location");
+        }
+
+        ShiftAssignment assignment = shiftAssignmentRepository.findByShiftIdAndEmployeeId(shiftId, employeeId)
+                .orElseThrow(() -> new ResourceNotFoundException("Assignment not found"));
+
+        shiftAssignmentRepository.delete(assignment);
+
+        String message = String.format(
+                "You have been removed from the shift on %s from %s to %s at %s.",
+                shift.getShiftDate(), shift.getStartTime(), shift.getEndTime(),
+                shift.getLocation().getName()
+        );
+        notificationService.notifyUser(
+                assignment.getEmployee().getUser().getId(),
+                NotificationType.SHIFT_REMOVED,
+                message,
+                "SHIFT",
+                shift.getId()
+        );
+    }
+
     private boolean isAvailabilityMismatch(Long employeeId, Shift shift) {
         boolean hasOverrideOnDate = availabilityOverrideRepository.hasOverlap(
                 employeeId,

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
@@ -5,12 +5,16 @@ import com.shiftsync.shiftsync.auth.repository.UserRepository;
 import com.shiftsync.shiftsync.availability.entity.RecurringAvailability;
 import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepository;
 import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepository;
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.enums.NotificationType;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.common.exception.UnprocessableEntityException;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
 import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
+import com.shiftsync.shiftsync.notification.service.NotificationService;
 import com.shiftsync.shiftsync.shift.dto.AssignEmployeeRequest;
 import com.shiftsync.shiftsync.shift.dto.AssignEmployeeResponse;
 import com.shiftsync.shiftsync.shift.entity.Shift;
@@ -24,6 +28,9 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -31,6 +38,7 @@ import java.util.List;
 public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
 
     private static final String AVAILABILITY_MISMATCH = "AVAILABILITY_MISMATCH";
+    private static final String OVERTIME_RISK = "OVERTIME_RISK";
 
     private final EmployeeRepository employeeRepository;
     private final UserRepository userRepository;
@@ -39,6 +47,8 @@ public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
     private final ManagerLocationRepository managerLocationRepository;
     private final RecurringAvailabilityRepository recurringAvailabilityRepository;
     private final AvailabilityOverrideRepository availabilityOverrideRepository;
+    private final LeaveRequestRepository leaveRequestRepository;
+    private final NotificationService notificationService;
 
     @Override
     @Transactional
@@ -69,17 +79,42 @@ public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
             throw new InvalidStateException("Employee is already assigned to this shift");
         }
 
-        // TODO (Week 3 - FR-CONFLICT-01): reject if employee already assigned to an overlapping shift -> 409
-        // TODO (Week 3 - FR-CONFLICT-02): reject if shift falls within an approved leave period -> 409
+        boolean doubleBooked = shiftAssignmentRepository.existsOverlappingAssignment(
+                employee.getId(),
+                shiftId,
+                shift.getShiftDate(),
+                shift.getStartTime(),
+                shift.getEndTime()
+        );
+        if (doubleBooked) {
+            throw new InvalidStateException("Employee is already assigned to an overlapping shift on this date");
+        }
 
-        boolean availabilityMismatch = isAvailabilityMismatch(employee.getId(), shift);
+        boolean onApprovedLeave = leaveRequestRepository.existsOverlappingByEmployeeAndStatuses(
+                employee.getId(),
+                shift.getShiftDate(),
+                shift.getShiftDate(),
+                List.of(LeaveStatus.APPROVED)
+        );
+        if (onApprovedLeave) {
+            throw new InvalidStateException("Employee has approved leave that overlaps with this shift");
+        }
 
-        // TODO (Week 3 - FR-CONFLICT-04): add overtime threshold warning to conflicts list
-        if (availabilityMismatch && !override) {
+        List<String> conflicts = new ArrayList<>();
+
+        if (isAvailabilityMismatch(employee.getId(), shift)) {
+            conflicts.add(AVAILABILITY_MISMATCH);
+        }
+
+        if (isOvertimeRisk(employee, shift)) {
+            conflicts.add(OVERTIME_RISK);
+        }
+
+        if (!conflicts.isEmpty() && !override) {
             return new AssignEmployeeResponse(
                     "WARNING",
-                    List.of(AVAILABILITY_MISMATCH),
-                    "Employee availability does not match this shift. Re-submit with override=true to proceed.",
+                    conflicts,
+                    "Conflicts detected. Re-submit with override=true to proceed.",
                     null
             );
         }
@@ -91,18 +126,26 @@ public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
                 .shift(shift)
                 .employee(employee)
                 .assignedBy(assignedBy)
-                .overrideApplied(availabilityMismatch)
-                .overrideReason(availabilityMismatch ? AVAILABILITY_MISMATCH : null)
+                .overrideApplied(!conflicts.isEmpty())
+                .overrideReason(!conflicts.isEmpty() ? String.join(", ", conflicts) : null)
                 .build();
 
         ShiftAssignment saved = shiftAssignmentRepository.save(assignment);
 
-        return new AssignEmployeeResponse(
-                "ASSIGNED",
-                List.of(),
-                "Employee assigned successfully",
-                saved.getId()
+        String message = String.format(
+                "You have been assigned to a shift on %s from %s to %s at %s.",
+                shift.getShiftDate(), shift.getStartTime(), shift.getEndTime(),
+                shift.getLocation().getName()
         );
+        notificationService.notifyUser(
+                employee.getUser().getId(),
+                NotificationType.SHIFT_ASSIGNED,
+                message,
+                "SHIFT",
+                shift.getId()
+        );
+
+        return new AssignEmployeeResponse("ASSIGNED", List.of(), "Employee assigned successfully", saved.getId());
     }
 
     private boolean isAvailabilityMismatch(Long employeeId, Shift shift) {
@@ -128,5 +171,22 @@ public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
                         && !shift.getEndTime().isAfter(window.getEndTime())
         );
     }
-}
 
+    private boolean isOvertimeRisk(Employee employee, Shift shift) {
+        var weekStart = shift.getShiftDate().with(DayOfWeek.MONDAY);
+        var weekEnd = shift.getShiftDate().with(DayOfWeek.SUNDAY);
+
+        List<ShiftAssignment> weekAssignments = shiftAssignmentRepository
+                .findByEmployeeInWeek(employee.getId(), weekStart, weekEnd);
+
+        double assignedHours = weekAssignments.stream()
+                .mapToDouble(a -> ChronoUnit.MINUTES.between(
+                        a.getShift().getStartTime(), a.getShift().getEndTime()) / 60.0)
+                .sum();
+
+        double newShiftHours = ChronoUnit.MINUTES.between(
+                shift.getStartTime(), shift.getEndTime()) / 60.0;
+
+        return (assignedHours + newShiftHours) > employee.getContractedWeeklyHours().doubleValue();
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
@@ -63,7 +63,7 @@ public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
         Employee manager = employeeRepository.findByUserId(actorUserId)
                 .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
 
-        Shift shift = shiftRepository.findById(shiftId)
+        Shift shift = shiftRepository.findByIdForUpdate(shiftId)
                 .orElseThrow(() -> new ResourceNotFoundException("Shift not found"));
 
         if (shift.getStatus() == ShiftStatus.CANCELLED) {

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
@@ -7,6 +7,8 @@ import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepos
 import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepository;
 import com.shiftsync.shiftsync.common.enums.LeaveStatus;
 import com.shiftsync.shiftsync.common.enums.NotificationType;
+import com.shiftsync.shiftsync.config.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.common.exception.UnprocessableEntityException;
@@ -52,6 +54,7 @@ public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
 
     @Override
     @Transactional
+    @CacheEvict(value = CacheConfig.LOCATION_SHIFTS, allEntries = true)
     public AssignEmployeeResponse assignEmployee(Long actorUserId, Long shiftId, AssignEmployeeRequest request, boolean override) {
         Employee manager = employeeRepository.findByUserId(actorUserId)
                 .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
@@ -150,6 +153,7 @@ public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
 
     @Override
     @Transactional
+    @CacheEvict(value = CacheConfig.LOCATION_SHIFTS, allEntries = true)
     public void removeAssignment(Long actorUserId, Long shiftId, Long employeeId) {
         Employee manager = employeeRepository.findByUserId(actorUserId)
                 .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftAssignmentServiceImpl.java
@@ -26,6 +26,7 @@ import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
 import com.shiftsync.shiftsync.shift.repository.ShiftRepository;
 import com.shiftsync.shiftsync.shift.service.ShiftAssignmentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +42,9 @@ public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
 
     private static final String AVAILABILITY_MISMATCH = "AVAILABILITY_MISMATCH";
     private static final String OVERTIME_RISK = "OVERTIME_RISK";
+
+    @Value("${shiftsync.overtime.buffer-multiplier:1.10}")
+    private double overtimeBufferMultiplier;
 
     private final EmployeeRepository employeeRepository;
     private final UserRepository userRepository;
@@ -224,6 +228,7 @@ public class ShiftAssignmentServiceImpl implements ShiftAssignmentService {
         double newShiftHours = ChronoUnit.MINUTES.between(
                 shift.getStartTime(), shift.getEndTime()) / 60.0;
 
-        return (assignedHours + newShiftHours) > employee.getContractedWeeklyHours().doubleValue();
+        double threshold = employee.getContractedWeeklyHours().doubleValue() * overtimeBufferMultiplier;
+        return (assignedHours + newShiftHours) > threshold;
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
@@ -1,0 +1,99 @@
+package com.shiftsync.shiftsync.shift.service.impl;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.auth.repository.UserRepository;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.department.entity.Department;
+import com.shiftsync.shiftsync.department.repository.DepartmentRepository;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.location.repository.LocationRepository;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
+import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
+import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
+import com.shiftsync.shiftsync.shift.entity.Shift;
+import com.shiftsync.shiftsync.shift.repository.ShiftRepository;
+import com.shiftsync.shiftsync.shift.service.ShiftService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftServiceImpl implements ShiftService {
+
+    private final UserRepository userRepository;
+    private final EmployeeRepository employeeRepository;
+    private final LocationRepository locationRepository;
+    private final DepartmentRepository departmentRepository;
+    private final ShiftRepository shiftRepository;
+    private final ManagerLocationRepository managerLocationRepository;
+
+    @Override
+    @Transactional
+    public ShiftResponse createShift(Long actorUserId, CreateShiftRequest request) {
+        if (!request.endTime().isAfter(request.startTime())) {
+            throw new BadRequestException("End time must be after start time");
+        }
+
+        User actor = userRepository.findById(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        if (actor.getRole() == UserRole.MANAGER) {
+            Employee manager = employeeRepository.findByUserId(actorUserId)
+                    .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
+            List<Long> assignedLocations = managerLocationRepository.findLocationIdsByManagerEmployeeId(manager.getId());
+            if (!assignedLocations.contains(request.locationId())) {
+                throw new AccessDeniedException("You are not assigned to this location");
+            }
+        }
+
+        Location location = locationRepository.findById(request.locationId())
+                .orElseThrow(() -> new ResourceNotFoundException("Location not found"));
+
+        Department department = departmentRepository.findById(request.departmentId())
+                .orElseThrow(() -> new ResourceNotFoundException("Department not found"));
+
+        if (!department.getLocation().getId().equals(request.locationId())) {
+            throw new BadRequestException("Department does not belong to the specified location");
+        }
+
+        Shift shift = Shift.builder()
+                .location(location)
+                .department(department)
+                .shiftDate(request.date())
+                .startTime(request.startTime())
+                .endTime(request.endTime())
+                .requiredSkill(request.requiredSkill())
+                .minimumHeadcount(request.minimumHeadcount())
+                .createdBy(actor)
+                .build();
+
+        Shift saved = shiftRepository.save(shift);
+
+        return toResponse(saved);
+    }
+
+    private ShiftResponse toResponse(Shift shift) {
+        return new ShiftResponse(
+                shift.getId(),
+                shift.getLocation().getId(),
+                shift.getLocation().getName(),
+                shift.getDepartment().getId(),
+                shift.getDepartment().getName(),
+                shift.getShiftDate(),
+                shift.getStartTime(),
+                shift.getEndTime(),
+                shift.getRequiredSkill(),
+                shift.getMinimumHeadcount(),
+                shift.getStatus().name(),
+                0
+        );
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
@@ -195,10 +195,7 @@ public class ShiftServiceImpl implements ShiftService {
 
     @Override
     @Transactional(readOnly = true)
-    @Cacheable(value = CacheConfig.LOCATION_SHIFTS,
-            key = "#locationId + ':' + #from + ':' + #to + ':' + (#departmentId ?: 'all') + ':' + #page")
-    public LocationShiftPageResponse getLocationShifts(Long actorUserId, Long locationId, LocalDate from, LocalDate to,
-                                                       Long departmentId, int page, int size) {
+    public void verifyManagerLocationAccess(Long actorUserId, Long locationId) {
         User actor = userRepository.findById(actorUserId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
@@ -210,11 +207,18 @@ public class ShiftServiceImpl implements ShiftService {
                 throw new AccessDeniedException("You are not assigned to this location");
             }
         }
+    }
 
+    @Override
+    @Transactional(readOnly = true)
+    @Cacheable(value = CacheConfig.LOCATION_SHIFTS,
+            key = "#locationId + ':' + #from + ':' + #to + ':' + (#departmentId ?: 'all') + ':' + #page")
+    public LocationShiftPageResponse getLocationShifts(Long locationId, LocalDate from, LocalDate to,
+                                                       Long departmentId, int page, int size) {
         List<Shift> allShifts = shiftRepository.findByLocationInRange(locationId, from, to);
 
         List<Shift> filtered = departmentId != null
-                ? allShifts.stream().filter(s -> s.getDepartment().getId().equals(departmentId)).collect(Collectors.toList())
+                ? allShifts.stream().filter(s -> s.getDepartment().getId().equals(departmentId)).toList()
                 : allShifts;
 
         int totalElements = filtered.size();

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
@@ -7,6 +7,7 @@ import com.shiftsync.shiftsync.common.enums.UserRole;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.config.CacheConfig;
 import com.shiftsync.shiftsync.department.entity.Department;
 import com.shiftsync.shiftsync.department.repository.DepartmentRepository;
 import com.shiftsync.shiftsync.employee.entity.Employee;
@@ -15,16 +16,22 @@ import com.shiftsync.shiftsync.location.entity.Location;
 import com.shiftsync.shiftsync.location.repository.LocationRepository;
 import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
 import com.shiftsync.shiftsync.notification.service.NotificationService;
+import com.shiftsync.shiftsync.shift.dto.AssigneeInfo;
 import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
 import com.shiftsync.shiftsync.shift.dto.EmployeeShiftResponse;
+import com.shiftsync.shiftsync.shift.dto.LocationShiftPageResponse;
+import com.shiftsync.shiftsync.shift.dto.LocationShiftResponse;
 import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
 import com.shiftsync.shiftsync.shift.entity.Shift;
 import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
 import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
+import com.shiftsync.shiftsync.shift.entity.StaffingStatus;
 import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
 import com.shiftsync.shiftsync.shift.repository.ShiftRepository;
 import com.shiftsync.shiftsync.shift.service.ShiftService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,6 +58,7 @@ public class ShiftServiceImpl implements ShiftService {
 
     @Override
     @Transactional
+    @CacheEvict(value = CacheConfig.LOCATION_SHIFTS, allEntries = true)
     public ShiftResponse createShift(Long actorUserId, CreateShiftRequest request) {
         if (!request.endTime().isAfter(request.startTime())) {
             throw new BadRequestException("End time must be after start time");
@@ -96,6 +104,7 @@ public class ShiftServiceImpl implements ShiftService {
 
     @Override
     @Transactional
+    @CacheEvict(value = CacheConfig.LOCATION_SHIFTS, allEntries = true)
     public void cancelShift(Long actorUserId, Long shiftId) {
         User actor = userRepository.findById(actorUserId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
@@ -182,6 +191,79 @@ public class ShiftServiceImpl implements ShiftService {
                     );
                 })
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @Cacheable(value = CacheConfig.LOCATION_SHIFTS,
+            key = "#locationId + ':' + #from + ':' + #to + ':' + (#departmentId ?: 'all') + ':' + #page")
+    public LocationShiftPageResponse getLocationShifts(Long actorUserId, Long locationId, LocalDate from, LocalDate to,
+                                                       Long departmentId, int page, int size) {
+        User actor = userRepository.findById(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        if (actor.getRole() == UserRole.MANAGER) {
+            Employee manager = employeeRepository.findByUserId(actorUserId)
+                    .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
+            List<Long> assignedLocations = managerLocationRepository.findLocationIdsByManagerEmployeeId(manager.getId());
+            if (!assignedLocations.contains(locationId)) {
+                throw new AccessDeniedException("You are not assigned to this location");
+            }
+        }
+
+        List<Shift> allShifts = shiftRepository.findByLocationInRange(locationId, from, to);
+
+        List<Shift> filtered = departmentId != null
+                ? allShifts.stream().filter(s -> s.getDepartment().getId().equals(departmentId)).collect(Collectors.toList())
+                : allShifts;
+
+        int totalElements = filtered.size();
+        int totalPages = size > 0 ? (int) Math.ceil((double) totalElements / size) : 0;
+        int start = page * size;
+        List<Shift> pageContent = start >= totalElements ? List.of() : filtered.subList(start, Math.min(start + size, totalElements));
+
+        if (pageContent.isEmpty()) {
+            return new LocationShiftPageResponse(List.of(), totalElements, totalPages, page);
+        }
+
+        Set<Long> shiftIds = pageContent.stream().map(Shift::getId).collect(Collectors.toSet());
+
+        Map<Long, List<ShiftAssignment>> assignmentsByShift = shiftAssignmentRepository
+                .findAssignmentsByShiftIds(shiftIds)
+                .stream()
+                .collect(Collectors.groupingBy(a -> a.getShift().getId()));
+
+        List<LocationShiftResponse> content = pageContent.stream()
+                .map(shift -> {
+                    List<ShiftAssignment> shiftAssignments = assignmentsByShift.getOrDefault(shift.getId(), List.of());
+                    int assignedCount = shiftAssignments.size();
+                    List<AssigneeInfo> assignees = shiftAssignments.stream()
+                            .map(a -> new AssigneeInfo(
+                                    a.getEmployee().getUser().getFullName(),
+                                    a.getEmployee().getEmploymentType().name()
+                            ))
+                            .collect(Collectors.toList());
+                    return new LocationShiftResponse(
+                            shift.getId(),
+                            shift.getShiftDate(),
+                            shift.getStartTime(),
+                            shift.getEndTime(),
+                            shift.getDepartment().getName(),
+                            shift.getMinimumHeadcount(),
+                            assignedCount,
+                            resolveStaffingStatus(assignedCount, shift.getMinimumHeadcount()),
+                            assignees
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new LocationShiftPageResponse(content, totalElements, totalPages, page);
+    }
+
+    private StaffingStatus resolveStaffingStatus(int assignedCount, int minimumHeadcount) {
+        if (assignedCount < minimumHeadcount) return StaffingStatus.UNDERSTAFFED;
+        if (assignedCount == minimumHeadcount) return StaffingStatus.FULLY_STAFFED;
+        return StaffingStatus.OVERSTAFFED;
     }
 
     private ShiftResponse toResponse(Shift shift) {

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
@@ -2,8 +2,10 @@ package com.shiftsync.shiftsync.shift.service.impl;
 
 import com.shiftsync.shiftsync.auth.entity.User;
 import com.shiftsync.shiftsync.auth.repository.UserRepository;
+import com.shiftsync.shiftsync.common.enums.NotificationType;
 import com.shiftsync.shiftsync.common.enums.UserRole;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.department.entity.Department;
 import com.shiftsync.shiftsync.department.repository.DepartmentRepository;
@@ -12,9 +14,13 @@ import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.location.entity.Location;
 import com.shiftsync.shiftsync.location.repository.LocationRepository;
 import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
+import com.shiftsync.shiftsync.notification.service.NotificationService;
 import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
 import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
 import com.shiftsync.shiftsync.shift.entity.Shift;
+import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
+import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
+import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
 import com.shiftsync.shiftsync.shift.repository.ShiftRepository;
 import com.shiftsync.shiftsync.shift.service.ShiftService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +28,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -33,7 +40,9 @@ public class ShiftServiceImpl implements ShiftService {
     private final LocationRepository locationRepository;
     private final DepartmentRepository departmentRepository;
     private final ShiftRepository shiftRepository;
+    private final ShiftAssignmentRepository shiftAssignmentRepository;
     private final ManagerLocationRepository managerLocationRepository;
+    private final NotificationService notificationService;
 
     @Override
     @Transactional
@@ -78,6 +87,49 @@ public class ShiftServiceImpl implements ShiftService {
         Shift saved = shiftRepository.save(shift);
 
         return toResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    public void cancelShift(Long actorUserId, Long shiftId) {
+        User actor = userRepository.findById(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        Shift shift = shiftRepository.findById(shiftId)
+                .orElseThrow(() -> new ResourceNotFoundException("Shift not found"));
+
+        if (shift.getStatus() == ShiftStatus.CANCELLED) {
+            throw new InvalidStateException("Shift is already cancelled");
+        }
+
+        if (actor.getRole() == UserRole.MANAGER) {
+            Employee manager = employeeRepository.findByUserId(actorUserId)
+                    .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
+            List<Long> assignedLocations = managerLocationRepository.findLocationIdsByManagerEmployeeId(manager.getId());
+            if (!assignedLocations.contains(shift.getLocation().getId())) {
+                throw new AccessDeniedException("You are not assigned to this location");
+            }
+        }
+
+        shift.setStatus(ShiftStatus.CANCELLED);
+        shift.setCancelledAt(LocalDateTime.now());
+        shiftRepository.save(shift);
+
+        List<ShiftAssignment> assignments = shiftAssignmentRepository.findByShiftId(shiftId);
+        String message = String.format(
+                "The shift on %s from %s to %s at %s has been cancelled.",
+                shift.getShiftDate(), shift.getStartTime(), shift.getEndTime(),
+                shift.getLocation().getName()
+        );
+        for (ShiftAssignment assignment : assignments) {
+            notificationService.notifyUser(
+                    assignment.getEmployee().getUser().getId(),
+                    NotificationType.SHIFT_CANCELLED,
+                    message,
+                    "SHIFT",
+                    shift.getId()
+            );
+        }
     }
 
     private ShiftResponse toResponse(Shift shift) {

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
@@ -16,6 +16,7 @@ import com.shiftsync.shiftsync.location.repository.LocationRepository;
 import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
 import com.shiftsync.shiftsync.notification.service.NotificationService;
 import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
+import com.shiftsync.shiftsync.shift.dto.EmployeeShiftResponse;
 import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
 import com.shiftsync.shiftsync.shift.entity.Shift;
 import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
@@ -28,8 +29,12 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -130,6 +135,53 @@ public class ShiftServiceImpl implements ShiftService {
                     shift.getId()
             );
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EmployeeShiftResponse> getMyShifts(Long actorUserId, LocalDate from, LocalDate to, boolean includeCancelled) {
+        Employee employee = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
+
+        List<ShiftStatus> statuses = includeCancelled
+                ? List.of(ShiftStatus.OPEN, ShiftStatus.CANCELLED)
+                : List.of(ShiftStatus.OPEN);
+
+        List<ShiftAssignment> assignments = shiftAssignmentRepository
+                .findByEmployeeInRange(employee.getId(), from, to, statuses);
+
+        if (assignments.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> shiftIds = assignments.stream()
+                .map(a -> a.getShift().getId())
+                .collect(Collectors.toSet());
+
+        Map<Long, List<String>> colleaguesByShift = shiftAssignmentRepository
+                .findColleaguesByShiftIds(shiftIds, employee.getId())
+                .stream()
+                .collect(Collectors.groupingBy(
+                        a -> a.getShift().getId(),
+                        Collectors.mapping(a -> a.getEmployee().getUser().getFullName(), Collectors.toList())
+                ));
+
+        return assignments.stream()
+                .map(a -> {
+                    Shift shift = a.getShift();
+                    List<String> colleagues = colleaguesByShift.getOrDefault(shift.getId(), List.of());
+                    return new EmployeeShiftResponse(
+                            shift.getId(),
+                            shift.getShiftDate(),
+                            shift.getStartTime(),
+                            shift.getEndTime(),
+                            shift.getLocation().getName(),
+                            shift.getDepartment().getName(),
+                            shift.getStatus().name(),
+                            colleagues
+                    );
+                })
+                .collect(Collectors.toList());
     }
 
     private ShiftResponse toResponse(Shift shift) {

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftSwapServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftSwapServiceImpl.java
@@ -1,0 +1,263 @@
+package com.shiftsync.shiftsync.shift.service.impl;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.auth.repository.UserRepository;
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.enums.NotificationType;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
+import com.shiftsync.shiftsync.notification.service.NotificationService;
+import com.shiftsync.shiftsync.shift.dto.ShiftSwapRequest;
+import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
+import com.shiftsync.shiftsync.shift.entity.Shift;
+import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
+import com.shiftsync.shiftsync.shift.entity.ShiftSwap;
+import com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus;
+import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
+import com.shiftsync.shiftsync.shift.repository.ShiftSwapRepository;
+import com.shiftsync.shiftsync.shift.service.ShiftSwapService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ShiftSwapServiceImpl implements ShiftSwapService {
+
+    private final EmployeeRepository employeeRepository;
+    private final UserRepository userRepository;
+    private final ShiftAssignmentRepository shiftAssignmentRepository;
+    private final ShiftSwapRepository shiftSwapRepository;
+    private final LeaveRequestRepository leaveRequestRepository;
+    private final NotificationService notificationService;
+
+    @Override
+    @Transactional
+    public ShiftSwapResponse requestSwap(Long actorUserId, ShiftSwapRequest request) {
+        Employee requester = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
+
+        ShiftAssignment requesterAssignment = shiftAssignmentRepository.findById(request.myShiftAssignmentId())
+                .orElseThrow(() -> new ResourceNotFoundException("Shift assignment not found"));
+
+        if (!requesterAssignment.getEmployee().getId().equals(requester.getId())) {
+            throw new BadRequestException("You are not assigned to the referenced shift");
+        }
+
+        Employee targetEmployee = employeeRepository.findById(request.targetEmployeeId())
+                .orElseThrow(() -> new ResourceNotFoundException("Target employee not found"));
+
+        ShiftAssignment targetAssignment = null;
+        if (request.targetShiftAssignmentId() != null) {
+            targetAssignment = shiftAssignmentRepository.findById(request.targetShiftAssignmentId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Target shift assignment not found"));
+            if (!targetAssignment.getEmployee().getId().equals(targetEmployee.getId())) {
+                throw new BadRequestException("Target assignment does not belong to the specified target employee");
+            }
+        }
+
+        ShiftSwap swap = ShiftSwap.builder()
+                .requester(requester)
+                .requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee)
+                .targetAssignment(targetAssignment)
+                .reason(request.reason())
+                .status(ShiftSwapStatus.PENDING_MANAGER_APPROVAL)
+                .build();
+
+        ShiftSwap saved = shiftSwapRepository.save(swap);
+
+        Shift requesterShift = requesterAssignment.getShift();
+        String proposalMessage = String.format(
+                "%s has requested a shift swap with you for the shift on %s from %s to %s at %s.",
+                requester.getUser().getFullName(),
+                requesterShift.getShiftDate(),
+                requesterShift.getStartTime(),
+                requesterShift.getEndTime(),
+                requesterShift.getLocation().getName()
+        );
+        notificationService.notifyUser(
+                targetEmployee.getUser().getId(),
+                NotificationType.SWAP_OUTCOME,
+                proposalMessage,
+                "SHIFT_SWAP",
+                saved.getId()
+        );
+
+        return toResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    public void approveSwap(Long actorUserId, Long swapId) {
+        User manager = userRepository.findById(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        ShiftSwap swap = shiftSwapRepository.findByIdWithDetails(swapId)
+                .orElseThrow(() -> new ResourceNotFoundException("Swap request not found"));
+
+        if (swap.getStatus() != ShiftSwapStatus.PENDING_MANAGER_APPROVAL) {
+            throw new InvalidStateException("Swap request is not pending approval");
+        }
+
+        ShiftAssignment requesterAssignment = swap.getRequesterAssignment();
+        ShiftAssignment targetAssignment = swap.getTargetAssignment();
+        Employee requester = swap.getRequester();
+        Employee targetEmployee = swap.getTargetEmployee();
+        Shift requesterShift = requesterAssignment.getShift();
+
+        List<Long> excludedShiftIds = new ArrayList<>();
+        excludedShiftIds.add(requesterShift.getId());
+        if (targetAssignment != null) {
+            excludedShiftIds.add(targetAssignment.getShift().getId());
+        }
+
+        checkConflictsForApproval(targetEmployee, requesterShift, excludedShiftIds);
+
+        if (targetAssignment != null) {
+            Shift targetShift = targetAssignment.getShift();
+            checkConflictsForApproval(requester, targetShift, excludedShiftIds);
+        }
+
+        requesterAssignment.setEmployee(targetEmployee);
+        requesterAssignment.setAssignedBy(manager);
+
+        if (targetAssignment != null) {
+            targetAssignment.setEmployee(requester);
+            targetAssignment.setAssignedBy(manager);
+        }
+
+        swap.setStatus(ShiftSwapStatus.APPROVED);
+        swap.setReviewedBy(manager);
+
+        String requesterMessage = String.format(
+                "Your shift swap request for %s has been approved.",
+                requesterShift.getShiftDate()
+        );
+        notificationService.notifyUser(
+                requester.getUser().getId(),
+                NotificationType.SWAP_OUTCOME,
+                requesterMessage,
+                "SHIFT_SWAP",
+                swapId
+        );
+
+        String targetMessage = String.format(
+                "The shift swap proposal for %s has been approved by management.",
+                requesterShift.getShiftDate()
+        );
+        notificationService.notifyUser(
+                targetEmployee.getUser().getId(),
+                NotificationType.SWAP_OUTCOME,
+                targetMessage,
+                "SHIFT_SWAP",
+                swapId
+        );
+    }
+
+    @Override
+    @Transactional
+    public void rejectSwap(Long actorUserId, Long swapId, String managerNote) {
+        User manager = userRepository.findById(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        ShiftSwap swap = shiftSwapRepository.findByIdWithDetails(swapId)
+                .orElseThrow(() -> new ResourceNotFoundException("Swap request not found"));
+
+        if (swap.getStatus() != ShiftSwapStatus.PENDING_MANAGER_APPROVAL) {
+            throw new InvalidStateException("Swap request is not pending approval");
+        }
+
+        swap.setStatus(ShiftSwapStatus.REJECTED);
+        swap.setReviewedBy(manager);
+        swap.setManagerNote(managerNote);
+
+        Shift requesterShift = swap.getRequesterAssignment().getShift();
+
+        String requesterMessage = String.format(
+                "Your shift swap request for %s has been rejected.%s",
+                requesterShift.getShiftDate(),
+                managerNote != null ? " Note: " + managerNote : ""
+        );
+        notificationService.notifyUser(
+                swap.getRequester().getUser().getId(),
+                NotificationType.SWAP_OUTCOME,
+                requesterMessage,
+                "SHIFT_SWAP",
+                swapId
+        );
+
+        String targetMessage = String.format(
+                "The shift swap proposal for %s has been rejected by management.",
+                requesterShift.getShiftDate()
+        );
+        notificationService.notifyUser(
+                swap.getTargetEmployee().getUser().getId(),
+                NotificationType.SWAP_OUTCOME,
+                targetMessage,
+                "SHIFT_SWAP",
+                swapId
+        );
+    }
+
+    private void checkConflictsForApproval(Employee employee, Shift newShift, List<Long> excludedShiftIds) {
+        boolean doubleBooked = shiftAssignmentRepository.existsConflictExcluding(
+                employee.getId(),
+                excludedShiftIds,
+                newShift.getShiftDate(),
+                newShift.getStartTime(),
+                newShift.getEndTime()
+        );
+        if (doubleBooked) {
+            throw new InvalidStateException(
+                    "Conflict detected: " + employee.getUser().getFullName()
+                            + " has an overlapping shift on " + newShift.getShiftDate()
+            );
+        }
+
+        boolean onLeave = leaveRequestRepository.existsOverlappingByEmployeeAndStatuses(
+                employee.getId(),
+                newShift.getShiftDate(),
+                newShift.getShiftDate(),
+                List.of(LeaveStatus.APPROVED)
+        );
+        if (onLeave) {
+            throw new InvalidStateException(
+                    "Conflict detected: " + employee.getUser().getFullName()
+                            + " has approved leave on " + newShift.getShiftDate()
+            );
+        }
+    }
+
+    private ShiftSwapResponse toResponse(ShiftSwap swap) {
+        Shift requesterShift = swap.getRequesterAssignment().getShift();
+        Shift targetShift = swap.getTargetAssignment() != null
+                ? swap.getTargetAssignment().getShift()
+                : null;
+
+        return new ShiftSwapResponse(
+                swap.getId(),
+                swap.getRequester().getId(),
+                swap.getRequester().getUser().getFullName(),
+                requesterShift.getShiftDate(),
+                requesterShift.getStartTime(),
+                requesterShift.getEndTime(),
+                swap.getTargetEmployee().getId(),
+                swap.getTargetEmployee().getUser().getFullName(),
+                targetShift != null ? targetShift.getShiftDate() : null,
+                targetShift != null ? targetShift.getStartTime() : null,
+                targetShift != null ? targetShift.getEndTime() : null,
+                swap.getStatus().name(),
+                swap.getReason(),
+                swap.getManagerNote(),
+                swap.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftSwapServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftSwapServiceImpl.java
@@ -7,6 +7,7 @@ import com.shiftsync.shiftsync.common.enums.NotificationType;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.config.CacheConfig;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
@@ -21,6 +22,7 @@ import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
 import com.shiftsync.shiftsync.shift.repository.ShiftSwapRepository;
 import com.shiftsync.shiftsync.shift.service.ShiftSwapService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -96,6 +98,7 @@ public class ShiftSwapServiceImpl implements ShiftSwapService {
 
     @Override
     @Transactional
+    @CacheEvict(value = CacheConfig.LOCATION_SHIFTS, allEntries = true)
     public void approveSwap(Long actorUserId, Long swapId) {
         User manager = userRepository.findById(actorUserId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));

--- a/src/main/resources/db/changelog/changes/005-add-shift-swap-table.xml
+++ b/src/main/resources/db/changelog/changes/005-add-shift-swap-table.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+
+    <changeSet id="005-001-create-shift-swap-status-enum" author="shiftsync">
+        <sql>
+            DO $$ BEGIN
+                CREATE TYPE shift_swap_status AS ENUM (
+                    'PENDING_MANAGER_APPROVAL',
+                    'APPROVED',
+                    'REJECTED'
+                );
+            EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+        </sql>
+    </changeSet>
+
+    <changeSet id="005-002-create-shift-swaps-table" author="shiftsync">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="shift_swaps"/>
+            </not>
+        </preConditions>
+        <createTable tableName="shift_swaps">
+            <column name="id" type="bigserial">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="requester_id" type="bigint">
+                <constraints nullable="false" foreignKeyName="fk_swap_requester"
+                             references="employees(id)"/>
+            </column>
+            <column name="requester_assignment_id" type="bigint">
+                <constraints nullable="false" foreignKeyName="fk_swap_requester_assignment"
+                             references="shift_assignments(id)"/>
+            </column>
+            <column name="target_employee_id" type="bigint">
+                <constraints nullable="false" foreignKeyName="fk_swap_target_employee"
+                             references="employees(id)"/>
+            </column>
+            <column name="target_assignment_id" type="bigint">
+                <constraints nullable="true" foreignKeyName="fk_swap_target_assignment"
+                             references="shift_assignments(id)"/>
+            </column>
+            <column name="reason" type="varchar(500)"/>
+            <column name="status" type="shift_swap_status">
+                <constraints nullable="false"/>
+            </column>
+            <column name="reviewed_by" type="bigint">
+                <constraints nullable="true" foreignKeyName="fk_swap_reviewed_by"
+                             references="users(id)"/>
+            </column>
+            <column name="manager_note" type="varchar(500)"/>
+            <column name="created_at" type="timestamp" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="timestamp" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -10,6 +10,7 @@
     <include file="db/changelog/changes/002-add-employees-notification-enabled.xml"/>
     <include file="db/changelog/changes/003-add-users-must-reset-password.xml"/>
     <include file="db/changelog/changes/004-add-availability-and-shift-tables.xml"/>
-    <include file="db/changelog/changes/005-leave-request-updates.xml"/>
+    <include file="db/changelog/changes/004-leave-request-updates.xml"/>
+    <include file="db/changelog/changes/005-add-shift-swap-table.xml"/>
 
 </databaseChangeLog>

--- a/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftControllerWebMvcTest.java
@@ -160,7 +160,7 @@ class ShiftControllerWebMvcTest {
     @WithMockUser(username = "1", roles = "MANAGER")
     void getLocationShifts_ValidRequest_ReturnsOk() throws Exception {
         LocationShiftPageResponse response = new LocationShiftPageResponse(List.of(), 0, 0, 0);
-        when(shiftService.getLocationShifts(anyLong(), eq(10L), any(), any(), any(), anyInt(), anyInt()))
+        when(shiftService.getLocationShifts(eq(10L), any(), any(), any(), anyInt(), anyInt()))
                 .thenReturn(response);
 
         mockMvc.perform(get("/api/v1/locations/10/shifts"))

--- a/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftControllerWebMvcTest.java
@@ -1,0 +1,170 @@
+package com.shiftsync.shiftsync.shift.controller;
+
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import com.shiftsync.shiftsync.shift.dto.LocationShiftPageResponse;
+import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
+import com.shiftsync.shiftsync.shift.service.ShiftService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest({ShiftController.class, LocationShiftController.class})
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, AuthenticationHelper.class})
+class ShiftControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ShiftService shiftService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    private static final String CREATE_BODY = """
+            {
+              "locationId": 10,
+              "departmentId": 20,
+              "date": "2026-06-01",
+              "startTime": "09:00:00",
+              "endTime": "17:00:00",
+              "minimumHeadcount": 2
+            }
+            """;
+
+    @Test
+    void createShift_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/v1/shifts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(CREATE_BODY))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "EMPLOYEE")
+    void createShift_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(post("/api/v1/shifts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(CREATE_BODY))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void createShift_ValidRequest_ReturnsCreated() throws Exception {
+        ShiftResponse response = new ShiftResponse(
+                50L, 10L, "HQ", 20L, "Engineering",
+                LocalDate.of(2026, 6, 1),
+                LocalTime.of(9, 0), LocalTime.of(17, 0),
+                null, 2, "OPEN", 0
+        );
+        when(shiftService.createShift(anyLong(), any())).thenReturn(response);
+
+        mockMvc.perform(post("/api/v1/shifts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(CREATE_BODY))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(50))
+                .andExpect(jsonPath("$.status").value("OPEN"))
+                .andExpect(jsonPath("$.assignedCount").value(0));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void createShift_InvalidTimeOrder_ReturnsBadRequest() throws Exception {
+        when(shiftService.createShift(anyLong(), any()))
+                .thenThrow(new BadRequestException("End time must be after start time"));
+
+        mockMvc.perform(post("/api/v1/shifts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(CREATE_BODY))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("End time must be after start time"));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void cancelShift_ValidRequest_ReturnsNoContent() throws Exception {
+        mockMvc.perform(patch("/api/v1/shifts/50/cancel"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void cancelShift_AlreadyCancelled_ReturnsConflict() throws Exception {
+        doThrow(new InvalidStateException("Shift is already cancelled"))
+                .when(shiftService).cancelShift(anyLong(), eq(50L));
+
+        mockMvc.perform(patch("/api/v1/shifts/50/cancel"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Shift is already cancelled"));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void cancelShift_NotFound_ReturnsNotFound() throws Exception {
+        doThrow(new ResourceNotFoundException("Shift not found"))
+                .when(shiftService).cancelShift(anyLong(), eq(99L));
+
+        mockMvc.perform(patch("/api/v1/shifts/99/cancel"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getLocationShifts_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/locations/10/shifts"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "EMPLOYEE")
+    void getLocationShifts_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/locations/10/shifts"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void getLocationShifts_ValidRequest_ReturnsOk() throws Exception {
+        LocationShiftPageResponse response = new LocationShiftPageResponse(List.of(), 0, 0, 0);
+        when(shiftService.getLocationShifts(anyLong(), eq(10L), any(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/api/v1/locations/10/shifts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+}

--- a/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapControllerWebMvcTest.java
@@ -1,0 +1,192 @@
+package com.shiftsync.shiftsync.shift.controller;
+
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
+import com.shiftsync.shiftsync.shift.service.ShiftSwapService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ShiftSwapController.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, AuthenticationHelper.class})
+class ShiftSwapControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ShiftSwapService shiftSwapService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    private static final String SWAP_REQUEST_BODY = """
+            {
+              "myShiftAssignmentId": 1,
+              "targetEmployeeId": 200,
+              "targetShiftAssignmentId": 2,
+              "reason": "Personal conflict"
+            }
+            """;
+
+    @Test
+    void requestSwap_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(post("/api/v1/shift-swaps")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(SWAP_REQUEST_BODY))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void requestSwap_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(post("/api/v1/shift-swaps")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(SWAP_REQUEST_BODY))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "EMPLOYEE")
+    void requestSwap_ValidRequest_ReturnsCreated() throws Exception {
+        ShiftSwapResponse response = new ShiftSwapResponse(
+                10L, 100L, "Alice",
+                LocalDate.of(2026, 6, 1), LocalTime.of(9, 0), LocalTime.of(17, 0),
+                200L, "Bob",
+                LocalDate.of(2026, 6, 2), LocalTime.of(9, 0), LocalTime.of(17, 0),
+                "PENDING_MANAGER_APPROVAL", "Personal conflict", null,
+                LocalDateTime.now()
+        );
+        when(shiftSwapService.requestSwap(anyLong(), any())).thenReturn(response);
+
+        mockMvc.perform(post("/api/v1/shift-swaps")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(SWAP_REQUEST_BODY))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(10))
+                .andExpect(jsonPath("$.status").value("PENDING_MANAGER_APPROVAL"))
+                .andExpect(jsonPath("$.requesterName").value("Alice"));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "EMPLOYEE")
+    void requestSwap_NotAssignedToShift_ReturnsBadRequest() throws Exception {
+        when(shiftSwapService.requestSwap(anyLong(), any()))
+                .thenThrow(new BadRequestException("You are not assigned to the referenced shift"));
+
+        mockMvc.perform(post("/api/v1/shift-swaps")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(SWAP_REQUEST_BODY))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("You are not assigned to the referenced shift"));
+    }
+
+    @Test
+    void approveSwap_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(patch("/api/v1/shift-swaps/10/approve"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "3", roles = "EMPLOYEE")
+    void approveSwap_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(patch("/api/v1/shift-swaps/10/approve"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "3", roles = "MANAGER")
+    void approveSwap_ValidRequest_ReturnsNoContent() throws Exception {
+        mockMvc.perform(patch("/api/v1/shift-swaps/10/approve"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(username = "3", roles = "MANAGER")
+    void approveSwap_ConflictDetected_ReturnsConflict() throws Exception {
+        doThrow(new InvalidStateException("Conflict detected: Bob has an overlapping shift"))
+                .when(shiftSwapService).approveSwap(anyLong(), eq(10L));
+
+        mockMvc.perform(patch("/api/v1/shift-swaps/10/approve"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Conflict detected: Bob has an overlapping shift"));
+    }
+
+    @Test
+    @WithMockUser(username = "3", roles = "MANAGER")
+    void approveSwap_NotPending_ReturnsConflict() throws Exception {
+        doThrow(new InvalidStateException("Swap request is not pending approval"))
+                .when(shiftSwapService).approveSwap(anyLong(), eq(99L));
+
+        mockMvc.perform(patch("/api/v1/shift-swaps/99/approve"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Swap request is not pending approval"));
+    }
+
+    @Test
+    @WithMockUser(username = "3", roles = "MANAGER")
+    void approveSwap_NotFound_ReturnsNotFound() throws Exception {
+        doThrow(new ResourceNotFoundException("Swap request not found"))
+                .when(shiftSwapService).approveSwap(anyLong(), eq(404L));
+
+        mockMvc.perform(patch("/api/v1/shift-swaps/404/approve"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "3", roles = "MANAGER")
+    void rejectSwap_WithNote_ReturnsNoContent() throws Exception {
+        mockMvc.perform(patch("/api/v1/shift-swaps/10/reject")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"managerNote\": \"Insufficient coverage\"}"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(username = "3", roles = "MANAGER")
+    void rejectSwap_WithoutBody_ReturnsNoContent() throws Exception {
+        mockMvc.perform(patch("/api/v1/shift-swaps/10/reject"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(username = "3", roles = "MANAGER")
+    void rejectSwap_NotPending_ReturnsConflict() throws Exception {
+        doThrow(new InvalidStateException("Swap request is not pending approval"))
+                .when(shiftSwapService).rejectSwap(anyLong(), eq(10L), any());
+
+        mockMvc.perform(patch("/api/v1/shift-swaps/10/reject"))
+                .andExpect(status().isConflict());
+    }
+}

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import org.springframework.test.util.ReflectionTestUtils;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -141,6 +142,8 @@ class ShiftAssignmentServiceImplTest {
                 .status(ShiftStatus.OPEN)
                 .createdBy(managerUser)
                 .build();
+
+        ReflectionTestUtils.setField(shiftAssignmentService, "overtimeBufferMultiplier", 1.10);
     }
 
     @Test
@@ -286,9 +289,10 @@ class ShiftAssignmentServiceImplTest {
                 .endTime(LocalTime.of(18, 0))
                 .build();
 
+        // 5 × 9h = 45h existing + 4h new shift = 49h > 44h threshold (40h * 1.10)
         ShiftAssignment existing = ShiftAssignment.builder()
                 .shift(Shift.builder()
-                        .startTime(LocalTime.of(9, 0)).endTime(LocalTime.of(17, 0))
+                        .startTime(LocalTime.of(9, 0)).endTime(LocalTime.of(18, 0))
                         .build())
                 .build();
 

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
@@ -6,13 +6,16 @@ import com.shiftsync.shiftsync.availability.entity.RecurringAvailability;
 import com.shiftsync.shiftsync.availability.repository.AvailabilityOverrideRepository;
 import com.shiftsync.shiftsync.availability.repository.RecurringAvailabilityRepository;
 import com.shiftsync.shiftsync.common.enums.EmploymentType;
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
 import com.shiftsync.shiftsync.common.enums.UserRole;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
 import com.shiftsync.shiftsync.common.exception.UnprocessableEntityException;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
 import com.shiftsync.shiftsync.location.entity.Location;
 import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
+import com.shiftsync.shiftsync.notification.service.NotificationService;
 import com.shiftsync.shiftsync.shift.dto.AssignEmployeeRequest;
 import com.shiftsync.shiftsync.shift.dto.AssignEmployeeResponse;
 import com.shiftsync.shiftsync.shift.entity.Shift;
@@ -66,6 +69,12 @@ class ShiftAssignmentServiceImplTest {
 
     @Mock
     private AvailabilityOverrideRepository availabilityOverrideRepository;
+
+    @Mock
+    private LeaveRequestRepository leaveRequestRepository;
+
+    @Mock
+    private NotificationService notificationService;
 
     @InjectMocks
     private ShiftAssignmentServiceImpl shiftAssignmentService;
@@ -234,6 +243,99 @@ class ShiftAssignmentServiceImplTest {
         assertThatThrownBy(() -> shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false))
                 .isInstanceOf(UnprocessableEntityException.class)
                 .hasMessage("Cannot assign an inactive employee to a shift");
+    }
+
+    @Test
+    void assignEmployee_DoubleBooked_ThrowsConflict() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
+        when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
+        when(shiftAssignmentRepository.existsOverlappingAssignment(
+                eq(20L), eq(100L), any(), any(), any())).thenReturn(true);
+
+        assertThatThrownBy(() -> shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessageContaining("overlapping shift");
+    }
+
+    @Test
+    void assignEmployee_OnApprovedLeave_ThrowsConflict() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
+        when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
+        when(shiftAssignmentRepository.existsOverlappingAssignment(any(), any(), any(), any(), any())).thenReturn(false);
+        when(leaveRequestRepository.existsOverlappingByEmployeeAndStatuses(
+                eq(20L), any(), any(), eq(List.of(LeaveStatus.APPROVED)))).thenReturn(true);
+
+        assertThatThrownBy(() -> shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessageContaining("approved leave");
+    }
+
+    @Test
+    void assignEmployee_OvertimeRisk_ReturnsWarning() {
+        RecurringAvailability recurring = RecurringAvailability.builder()
+                .employee(employee)
+                .dayOfWeek(java.time.DayOfWeek.MONDAY)
+                .startTime(LocalTime.of(8, 0))
+                .endTime(LocalTime.of(18, 0))
+                .build();
+
+        ShiftAssignment existing = ShiftAssignment.builder()
+                .shift(Shift.builder()
+                        .startTime(LocalTime.of(9, 0)).endTime(LocalTime.of(17, 0))
+                        .build())
+                .build();
+
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
+        when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
+        when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
+        when(shiftAssignmentRepository.existsOverlappingAssignment(any(), any(), any(), any(), any())).thenReturn(false);
+        when(leaveRequestRepository.existsOverlappingByEmployeeAndStatuses(any(), any(), any(), any())).thenReturn(false);
+        when(availabilityOverrideRepository.hasOverlap(any(), any(), any())).thenReturn(false);
+        when(recurringAvailabilityRepository.findByEmployeeAndDay(any(), any())).thenReturn(List.of(recurring));
+        when(shiftAssignmentRepository.findByEmployeeInWeek(any(), any(), any()))
+                .thenReturn(List.of(existing, existing, existing, existing, existing));
+
+        AssignEmployeeResponse response = shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false);
+
+        assertThat(response.status()).isEqualTo("WARNING");
+        assertThat(response.conflicts()).contains("OVERTIME_RISK");
+    }
+
+    @Test
+    void removeAssignment_ExistingAssignment_DeletesAndNotifies() {
+        ShiftAssignment assignment = ShiftAssignment.builder()
+                .id(1L).shift(shift).employee(employee).assignedBy(managerUser)
+                .overrideApplied(false).build();
+
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
+        when(shiftAssignmentRepository.findByShiftIdAndEmployeeId(100L, 20L)).thenReturn(Optional.of(assignment));
+
+        shiftAssignmentService.removeAssignment(5L, 100L, 20L);
+
+        verify(shiftAssignmentRepository).delete(assignment);
+        verify(notificationService).notifyUser(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void removeAssignment_AssignmentNotFound_ThrowsNotFound() {
+        when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
+        when(shiftAssignmentRepository.findByShiftIdAndEmployeeId(100L, 20L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> shiftAssignmentService.removeAssignment(5L, 100L, 20L))
+                .isInstanceOf(com.shiftsync.shiftsync.common.exception.ResourceNotFoundException.class)
+                .hasMessage("Assignment not found");
     }
 }
 

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
@@ -321,7 +321,7 @@ class ShiftAssignmentServiceImplTest {
                 .overrideApplied(false).build();
 
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
         when(shiftAssignmentRepository.findByShiftIdAndEmployeeId(100L, 20L)).thenReturn(Optional.of(assignment));
 
@@ -334,7 +334,7 @@ class ShiftAssignmentServiceImplTest {
     @Test
     void removeAssignment_AssignmentNotFound_ThrowsNotFound() {
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
         when(shiftAssignmentRepository.findByShiftIdAndEmployeeId(100L, 20L)).thenReturn(Optional.empty());
 

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
@@ -149,7 +149,7 @@ class ShiftAssignmentServiceImplTest {
     @Test
     void assignEmployee_OutsideAvailability_ReturnsWarningAndDoesNotSave() {
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
         when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
         when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
@@ -166,7 +166,7 @@ class ShiftAssignmentServiceImplTest {
     @Test
     void assignEmployee_OutsideAvailabilityWithOverride_CreatesAssignment() {
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
         when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
         when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
@@ -194,7 +194,7 @@ class ShiftAssignmentServiceImplTest {
                 .build();
 
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
         when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
         when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
@@ -216,7 +216,7 @@ class ShiftAssignmentServiceImplTest {
     @Test
     void assignEmployee_ManagerNotAssignedToLocation_ThrowsForbidden() {
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(2L));
 
         assertThatThrownBy(() -> shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false))
@@ -228,7 +228,7 @@ class ShiftAssignmentServiceImplTest {
     void assignEmployee_CancelledShift_ThrowsConflict() {
         shift.setStatus(ShiftStatus.CANCELLED);
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
 
         assertThatThrownBy(() -> shiftAssignmentService.assignEmployee(5L, 100L, new AssignEmployeeRequest(20L), false))
                 .isInstanceOf(InvalidStateException.class)
@@ -240,7 +240,7 @@ class ShiftAssignmentServiceImplTest {
         employee.setActive(false);
 
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
         when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
 
@@ -252,7 +252,7 @@ class ShiftAssignmentServiceImplTest {
     @Test
     void assignEmployee_DoubleBooked_ThrowsConflict() {
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
         when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
         when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
@@ -267,7 +267,7 @@ class ShiftAssignmentServiceImplTest {
     @Test
     void assignEmployee_OnApprovedLeave_ThrowsConflict() {
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
         when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
         when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
@@ -297,7 +297,7 @@ class ShiftAssignmentServiceImplTest {
                 .build();
 
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
         when(employeeRepository.findById(20L)).thenReturn(Optional.of(employee));
         when(shiftAssignmentRepository.existsByShiftIdAndEmployeeId(100L, 20L)).thenReturn(false);
@@ -321,7 +321,7 @@ class ShiftAssignmentServiceImplTest {
                 .overrideApplied(false).build();
 
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
         when(shiftAssignmentRepository.findByShiftIdAndEmployeeId(100L, 20L)).thenReturn(Optional.of(assignment));
 
@@ -334,7 +334,7 @@ class ShiftAssignmentServiceImplTest {
     @Test
     void removeAssignment_AssignmentNotFound_ThrowsNotFound() {
         when(employeeRepository.findByUserId(5L)).thenReturn(Optional.of(manager));
-        when(shiftRepository.findById(100L)).thenReturn(Optional.of(shift));
+        when(shiftRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(shift));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(10L)).thenReturn(List.of(1L));
         when(shiftAssignmentRepository.findByShiftIdAndEmployeeId(100L, 20L)).thenReturn(Optional.empty());
 

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentServiceImplTest.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftServiceImplTest.java
@@ -1,0 +1,327 @@
+package com.shiftsync.shiftsync.shift.service;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.auth.repository.UserRepository;
+import com.shiftsync.shiftsync.common.enums.EmploymentType;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.department.entity.Department;
+import com.shiftsync.shiftsync.department.repository.DepartmentRepository;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.location.repository.LocationRepository;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
+import com.shiftsync.shiftsync.notification.service.NotificationService;
+import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
+import com.shiftsync.shiftsync.shift.dto.EmployeeShiftResponse;
+import com.shiftsync.shiftsync.shift.dto.LocationShiftPageResponse;
+import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
+import com.shiftsync.shiftsync.shift.entity.Shift;
+import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
+import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
+import com.shiftsync.shiftsync.shift.entity.StaffingStatus;
+import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
+import com.shiftsync.shiftsync.shift.repository.ShiftRepository;
+import com.shiftsync.shiftsync.shift.service.impl.ShiftServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ShiftServiceImplTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private LocationRepository locationRepository;
+    @Mock private DepartmentRepository departmentRepository;
+    @Mock private ShiftRepository shiftRepository;
+    @Mock private ShiftAssignmentRepository shiftAssignmentRepository;
+    @Mock private ManagerLocationRepository managerLocationRepository;
+    @Mock private NotificationService notificationService;
+
+    @InjectMocks
+    private ShiftServiceImpl shiftService;
+
+    private User managerUser;
+    private User hrAdminUser;
+    private Employee manager;
+    private Employee employee;
+    private Location location;
+    private Department department;
+    private Shift shift;
+
+    @BeforeEach
+    void setUp() {
+        managerUser = User.builder().id(1L).fullName("Manager").role(UserRole.MANAGER).build();
+        hrAdminUser = User.builder().id(2L).fullName("HR Admin").role(UserRole.HR_ADMIN).build();
+
+        location = Location.builder().id(10L).name("HQ").address("Accra").maxHeadcountPerShift(10).active(true).build();
+        department = Department.builder().id(20L).name("Engineering").location(location).build();
+
+        manager = Employee.builder()
+                .id(100L).user(managerUser)
+                .employmentType(EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("40.00"))
+                .hireDate(LocalDate.of(2025, 1, 1))
+                .active(true).notificationEnabled(true)
+                .build();
+
+        User employeeUser = User.builder().id(3L).fullName("John Doe").role(UserRole.EMPLOYEE).build();
+        employee = Employee.builder()
+                .id(200L).user(employeeUser)
+                .employmentType(EmploymentType.PART_TIME)
+                .contractedWeeklyHours(new BigDecimal("20.00"))
+                .hireDate(LocalDate.of(2025, 6, 1))
+                .active(true).notificationEnabled(true)
+                .build();
+
+        shift = Shift.builder()
+                .id(50L).location(location).department(department)
+                .shiftDate(LocalDate.of(2026, 6, 1))
+                .startTime(LocalTime.of(9, 0)).endTime(LocalTime.of(17, 0))
+                .minimumHeadcount(2).status(ShiftStatus.OPEN).createdBy(managerUser)
+                .build();
+    }
+
+    @Test
+    void createShift_ValidManagerRequest_ReturnsShiftResponse() {
+        CreateShiftRequest request = new CreateShiftRequest(
+                10L, 20L, LocalDate.of(2026, 6, 1),
+                LocalTime.of(9, 0), LocalTime.of(17, 0), null, 2
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(manager));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(100L)).thenReturn(List.of(10L));
+        when(locationRepository.findById(10L)).thenReturn(Optional.of(location));
+        when(departmentRepository.findById(20L)).thenReturn(Optional.of(department));
+        when(shiftRepository.save(any(Shift.class))).thenReturn(shift);
+
+        ShiftResponse response = shiftService.createShift(1L, request);
+
+        assertThat(response.id()).isEqualTo(50L);
+        assertThat(response.status()).isEqualTo("OPEN");
+        assertThat(response.assignedCount()).isEqualTo(0);
+        verify(shiftRepository).save(any(Shift.class));
+    }
+
+    @Test
+    void createShift_EndTimeBeforeStartTime_ThrowsBadRequest() {
+        CreateShiftRequest request = new CreateShiftRequest(
+                10L, 20L, LocalDate.of(2026, 6, 1),
+                LocalTime.of(17, 0), LocalTime.of(9, 0), null, 1
+        );
+
+        assertThatThrownBy(() -> shiftService.createShift(1L, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("End time must be after start time");
+
+        verify(shiftRepository, never()).save(any());
+    }
+
+    @Test
+    void createShift_ManagerNotAssignedToLocation_ThrowsAccessDenied() {
+        CreateShiftRequest request = new CreateShiftRequest(
+                10L, 20L, LocalDate.of(2026, 6, 1),
+                LocalTime.of(9, 0), LocalTime.of(17, 0), null, 1
+        );
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(manager));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(100L)).thenReturn(List.of(99L));
+
+        assertThatThrownBy(() -> shiftService.createShift(1L, request))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void createShift_HrAdminBypassesLocationCheck_CreatesShift() {
+        CreateShiftRequest request = new CreateShiftRequest(
+                10L, 20L, LocalDate.of(2026, 6, 1),
+                LocalTime.of(9, 0), LocalTime.of(17, 0), null, 1
+        );
+
+        when(userRepository.findById(2L)).thenReturn(Optional.of(hrAdminUser));
+        when(locationRepository.findById(10L)).thenReturn(Optional.of(location));
+        when(departmentRepository.findById(20L)).thenReturn(Optional.of(department));
+        when(shiftRepository.save(any(Shift.class))).thenReturn(shift);
+
+        ShiftResponse response = shiftService.createShift(2L, request);
+
+        assertThat(response).isNotNull();
+        verify(employeeRepository, never()).findByUserId(2L);
+    }
+
+    @Test
+    void createShift_DepartmentNotInLocation_ThrowsBadRequest() {
+        Location otherLocation = Location.builder().id(99L).name("Other").address("X").maxHeadcountPerShift(5).active(true).build();
+        Department wrongDept = Department.builder().id(20L).name("Sales").location(otherLocation).build();
+
+        CreateShiftRequest request = new CreateShiftRequest(
+                10L, 20L, LocalDate.of(2026, 6, 1),
+                LocalTime.of(9, 0), LocalTime.of(17, 0), null, 1
+        );
+
+        when(userRepository.findById(2L)).thenReturn(Optional.of(hrAdminUser));
+        when(locationRepository.findById(10L)).thenReturn(Optional.of(location));
+        when(departmentRepository.findById(20L)).thenReturn(Optional.of(wrongDept));
+
+        assertThatThrownBy(() -> shiftService.createShift(2L, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Department does not belong to the specified location");
+    }
+
+    @Test
+    void cancelShift_OpenShift_CancelsAndNotifiesAssignees() {
+        ShiftAssignment assignment = ShiftAssignment.builder()
+                .id(1L).shift(shift).employee(employee).assignedBy(managerUser)
+                .overrideApplied(false).build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(shiftRepository.findById(50L)).thenReturn(Optional.of(shift));
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(manager));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(100L)).thenReturn(List.of(10L));
+        when(shiftAssignmentRepository.findByShiftId(50L)).thenReturn(List.of(assignment));
+
+        shiftService.cancelShift(1L, 50L);
+
+        assertThat(shift.getStatus()).isEqualTo(ShiftStatus.CANCELLED);
+        assertThat(shift.getCancelledAt()).isNotNull();
+        verify(notificationService).notifyUser(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void cancelShift_AlreadyCancelled_ThrowsConflict() {
+        shift.setStatus(ShiftStatus.CANCELLED);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(shiftRepository.findById(50L)).thenReturn(Optional.of(shift));
+
+        assertThatThrownBy(() -> shiftService.cancelShift(1L, 50L))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Shift is already cancelled");
+    }
+
+    @Test
+    void cancelShift_ShiftNotFound_ThrowsNotFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(shiftRepository.findById(50L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> shiftService.cancelShift(1L, 50L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void getMyShifts_EmployeeHasShifts_ReturnsResponsesWithColleagues() {
+        ShiftAssignment myAssignment = ShiftAssignment.builder()
+                .id(1L).shift(shift).employee(employee).assignedBy(managerUser)
+                .overrideApplied(false).build();
+
+        User colleagueUser = User.builder().id(4L).fullName("Jane Smith").role(UserRole.EMPLOYEE).build();
+        Employee colleague = Employee.builder().id(300L).user(colleagueUser)
+                .employmentType(EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("40")).hireDate(LocalDate.now())
+                .active(true).notificationEnabled(true).build();
+        ShiftAssignment colleagueAssignment = ShiftAssignment.builder()
+                .id(2L).shift(shift).employee(colleague).assignedBy(managerUser)
+                .overrideApplied(false).build();
+
+        when(employeeRepository.findByUserId(3L)).thenReturn(Optional.of(employee));
+        when(shiftAssignmentRepository.findByEmployeeInRange(any(), any(), any(), any()))
+                .thenReturn(List.of(myAssignment));
+        when(shiftAssignmentRepository.findColleaguesByShiftIds(any(), any()))
+                .thenReturn(List.of(colleagueAssignment));
+
+        List<EmployeeShiftResponse> result = shiftService.getMyShifts(
+                3L, LocalDate.now(), LocalDate.now().plusDays(7), false
+        );
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).shiftId()).isEqualTo(50L);
+        assertThat(result.get(0).assignedColleagues()).containsExactly("Jane Smith");
+    }
+
+    @Test
+    void getMyShifts_NoShifts_ReturnsEmptyList() {
+        when(employeeRepository.findByUserId(3L)).thenReturn(Optional.of(employee));
+        when(shiftAssignmentRepository.findByEmployeeInRange(any(), any(), any(), any()))
+                .thenReturn(List.of());
+
+        List<EmployeeShiftResponse> result = shiftService.getMyShifts(
+                3L, LocalDate.now(), LocalDate.now().plusDays(7), false
+        );
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getLocationShifts_ManagerAssignedToLocation_ReturnsPageWithStaffingStatus() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(manager));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(100L)).thenReturn(List.of(10L));
+        when(shiftRepository.findByLocationInRange(10L, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 7)))
+                .thenReturn(List.of(shift));
+        when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of());
+
+        LocationShiftPageResponse response = shiftService.getLocationShifts(
+                1L, 10L, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 7), null, 0, 20
+        );
+
+        assertThat(response.totalElements()).isEqualTo(1);
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().get(0).staffingStatus()).isEqualTo(StaffingStatus.UNDERSTAFFED);
+        assertThat(response.content().get(0).assignedCount()).isEqualTo(0);
+    }
+
+    @Test
+    void getLocationShifts_ManagerNotAssigned_ThrowsAccessDenied() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(manager));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(100L)).thenReturn(List.of(99L));
+
+        assertThatThrownBy(() -> shiftService.getLocationShifts(
+                1L, 10L, LocalDate.now(), LocalDate.now().plusDays(6), null, 0, 20
+        )).isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void getLocationShifts_WithDepartmentFilter_ReturnsOnlyMatchingShifts() {
+        Department otherDept = Department.builder().id(99L).name("HR").location(location).build();
+        Shift otherShift = Shift.builder().id(51L).location(location).department(otherDept)
+                .shiftDate(LocalDate.of(2026, 6, 2)).startTime(LocalTime.of(8, 0))
+                .endTime(LocalTime.of(16, 0)).minimumHeadcount(1).status(ShiftStatus.OPEN)
+                .createdBy(managerUser).build();
+
+        when(userRepository.findById(2L)).thenReturn(Optional.of(hrAdminUser));
+        when(shiftRepository.findByLocationInRange(10L, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 7)))
+                .thenReturn(List.of(shift, otherShift));
+        when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of());
+
+        LocationShiftPageResponse response = shiftService.getLocationShifts(
+                2L, 10L, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 7), 20L, 0, 20
+        );
+
+        assertThat(response.totalElements()).isEqualTo(1);
+        assertThat(response.content().get(0).shiftId()).isEqualTo(50L);
+    }
+}

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftServiceImplTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -257,8 +258,8 @@ class ShiftServiceImplTest {
         );
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).shiftId()).isEqualTo(50L);
-        assertThat(result.get(0).assignedColleagues()).containsExactly("Jane Smith");
+        assertThat(result.getFirst().shiftId()).isEqualTo(50L);
+        assertThat(result.getFirst().assignedColleagues()).containsExactly("Jane Smith");
     }
 
     @Test
@@ -275,33 +276,39 @@ class ShiftServiceImplTest {
     }
 
     @Test
-    void getLocationShifts_ManagerAssignedToLocation_ReturnsPageWithStaffingStatus() {
-        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
-        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(manager));
-        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(100L)).thenReturn(List.of(10L));
+    void getLocationShifts_ReturnsPageWithStaffingStatus() {
         when(shiftRepository.findByLocationInRange(10L, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 7)))
                 .thenReturn(List.of(shift));
         when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of());
 
         LocationShiftPageResponse response = shiftService.getLocationShifts(
-                1L, 10L, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 7), null, 0, 20
+                10L, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 7), null, 0, 20
         );
 
         assertThat(response.totalElements()).isEqualTo(1);
         assertThat(response.content()).hasSize(1);
-        assertThat(response.content().get(0).staffingStatus()).isEqualTo(StaffingStatus.UNDERSTAFFED);
-        assertThat(response.content().get(0).assignedCount()).isEqualTo(0);
+        assertThat(response.content().getFirst().staffingStatus()).isEqualTo(StaffingStatus.UNDERSTAFFED);
+        assertThat(response.content().getFirst().assignedCount()).isEqualTo(0);
     }
 
     @Test
-    void getLocationShifts_ManagerNotAssigned_ThrowsAccessDenied() {
+    void verifyManagerLocationAccess_ManagerNotAssigned_ThrowsAccessDenied() {
         when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
         when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(manager));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(100L)).thenReturn(List.of(99L));
 
-        assertThatThrownBy(() -> shiftService.getLocationShifts(
-                1L, 10L, LocalDate.now(), LocalDate.now().plusDays(6), null, 0, 20
-        )).isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> shiftService.verifyManagerLocationAccess(1L, 10L))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void verifyManagerLocationAccess_ManagerAssigned_DoesNotThrow() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(manager));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(100L)).thenReturn(List.of(10L));
+
+        assertThatCode(() -> shiftService.verifyManagerLocationAccess(1L, 10L))
+                .doesNotThrowAnyException();
     }
 
     @Test
@@ -312,16 +319,15 @@ class ShiftServiceImplTest {
                 .endTime(LocalTime.of(16, 0)).minimumHeadcount(1).status(ShiftStatus.OPEN)
                 .createdBy(managerUser).build();
 
-        when(userRepository.findById(2L)).thenReturn(Optional.of(hrAdminUser));
         when(shiftRepository.findByLocationInRange(10L, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 7)))
                 .thenReturn(List.of(shift, otherShift));
         when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of());
 
         LocationShiftPageResponse response = shiftService.getLocationShifts(
-                2L, 10L, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 7), 20L, 0, 20
+                10L, LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 7), 20L, 0, 20
         );
 
         assertThat(response.totalElements()).isEqualTo(1);
-        assertThat(response.content().get(0).shiftId()).isEqualTo(50L);
+        assertThat(response.content().getFirst().shiftId()).isEqualTo(50L);
     }
 }

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftSwapServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftSwapServiceImplTest.java
@@ -1,0 +1,288 @@
+package com.shiftsync.shiftsync.shift.service;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.auth.repository.UserRepository;
+import com.shiftsync.shiftsync.common.enums.EmploymentType;
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
+import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
+import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.notification.service.NotificationService;
+import com.shiftsync.shiftsync.shift.dto.ShiftSwapRequest;
+import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
+import com.shiftsync.shiftsync.shift.entity.Shift;
+import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
+import com.shiftsync.shiftsync.shift.entity.ShiftSwap;
+import com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus;
+import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
+import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
+import com.shiftsync.shiftsync.shift.repository.ShiftSwapRepository;
+import com.shiftsync.shiftsync.shift.service.impl.ShiftSwapServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ShiftSwapServiceImplTest {
+
+    @Mock private EmployeeRepository employeeRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ShiftAssignmentRepository shiftAssignmentRepository;
+    @Mock private ShiftSwapRepository shiftSwapRepository;
+    @Mock private LeaveRequestRepository leaveRequestRepository;
+    @Mock private NotificationService notificationService;
+
+    @InjectMocks
+    private ShiftSwapServiceImpl shiftSwapService;
+
+    private User managerUser;
+    private Employee requester;
+    private Employee targetEmployee;
+    private Shift requesterShift;
+    private ShiftAssignment requesterAssignment;
+    private ShiftAssignment targetAssignment;
+
+    @BeforeEach
+    void setUp() {
+        User requesterUser = User.builder().id(1L).fullName("Alice").role(UserRole.EMPLOYEE).build();
+        User targetUser = User.builder().id(2L).fullName("Bob").role(UserRole.EMPLOYEE).build();
+        managerUser = User.builder().id(3L).fullName("Manager").role(UserRole.MANAGER).build();
+
+        Location location = Location.builder().id(10L).name("HQ").address("Accra").maxHeadcountPerShift(10).active(true).build();
+
+        requester = Employee.builder().id(100L).user(requesterUser)
+                .employmentType(EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("40.00"))
+                .hireDate(LocalDate.of(2025, 1, 1))
+                .active(true).notificationEnabled(true).build();
+
+        targetEmployee = Employee.builder().id(200L).user(targetUser)
+                .employmentType(EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("40.00"))
+                .hireDate(LocalDate.of(2025, 1, 1))
+                .active(true).notificationEnabled(true).build();
+
+        requesterShift = Shift.builder()
+                .id(50L).location(location)
+                .shiftDate(LocalDate.of(2026, 6, 1))
+                .startTime(LocalTime.of(9, 0)).endTime(LocalTime.of(17, 0))
+                .minimumHeadcount(2).status(ShiftStatus.OPEN).createdBy(managerUser).build();
+
+        Shift targetShift = Shift.builder()
+                .id(51L).location(location)
+                .shiftDate(LocalDate.of(2026, 6, 2))
+                .startTime(LocalTime.of(9, 0)).endTime(LocalTime.of(17, 0))
+                .minimumHeadcount(2).status(ShiftStatus.OPEN).createdBy(managerUser).build();
+
+        requesterAssignment = ShiftAssignment.builder()
+                .id(1L).shift(requesterShift).employee(requester).assignedBy(managerUser)
+                .overrideApplied(false).build();
+
+        targetAssignment = ShiftAssignment.builder()
+                .id(2L).shift(targetShift).employee(targetEmployee).assignedBy(managerUser)
+                .overrideApplied(false).build();
+    }
+
+    @Test
+    void requestSwap_TwoWaySwap_ReturnsPendingResponse() {
+        ShiftSwapRequest request = new ShiftSwapRequest(1L, 200L, 2L, "Personal conflict");
+
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(requester));
+        when(shiftAssignmentRepository.findById(1L)).thenReturn(Optional.of(requesterAssignment));
+        when(employeeRepository.findById(200L)).thenReturn(Optional.of(targetEmployee));
+        when(shiftAssignmentRepository.findById(2L)).thenReturn(Optional.of(targetAssignment));
+
+        ShiftSwap savedSwap = ShiftSwap.builder()
+                .id(10L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(targetAssignment)
+                .reason("Personal conflict").status(ShiftSwapStatus.PENDING_MANAGER_APPROVAL)
+                .build();
+        when(shiftSwapRepository.save(any(ShiftSwap.class))).thenReturn(savedSwap);
+
+        ShiftSwapResponse response = shiftSwapService.requestSwap(1L, request);
+
+        assertThat(response.id()).isEqualTo(10L);
+        assertThat(response.status()).isEqualTo("PENDING_MANAGER_APPROVAL");
+        assertThat(response.requesterName()).isEqualTo("Alice");
+        assertThat(response.targetEmployeeName()).isEqualTo("Bob");
+        verify(notificationService).notifyUser(eq(2L), any(), any(), any(), any());
+    }
+
+    @Test
+    void requestSwap_CoverRequest_NoTargetAssignment_ReturnsPending() {
+        ShiftSwapRequest request = new ShiftSwapRequest(1L, 200L, null, "Need cover");
+
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(requester));
+        when(shiftAssignmentRepository.findById(1L)).thenReturn(Optional.of(requesterAssignment));
+        when(employeeRepository.findById(200L)).thenReturn(Optional.of(targetEmployee));
+
+        ShiftSwap savedSwap = ShiftSwap.builder()
+                .id(11L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(null)
+                .reason("Need cover").status(ShiftSwapStatus.PENDING_MANAGER_APPROVAL)
+                .build();
+        when(shiftSwapRepository.save(any(ShiftSwap.class))).thenReturn(savedSwap);
+
+        ShiftSwapResponse response = shiftSwapService.requestSwap(1L, request);
+
+        assertThat(response.status()).isEqualTo("PENDING_MANAGER_APPROVAL");
+        assertThat(response.targetShiftDate()).isNull();
+    }
+
+    @Test
+    void requestSwap_RequesterNotAssignedToShift_ThrowsBadRequest() {
+        ShiftSwapRequest request = new ShiftSwapRequest(1L, 200L, null, null);
+
+        ShiftAssignment otherAssignment = ShiftAssignment.builder()
+                .id(1L).shift(requesterShift).employee(targetEmployee)
+                .assignedBy(managerUser).overrideApplied(false).build();
+
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(requester));
+        when(shiftAssignmentRepository.findById(1L)).thenReturn(Optional.of(otherAssignment));
+
+        assertThatThrownBy(() -> shiftSwapService.requestSwap(1L, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("You are not assigned to the referenced shift");
+
+        verify(shiftSwapRepository, never()).save(any());
+    }
+
+    @Test
+    void requestSwap_AssignmentNotFound_ThrowsNotFound() {
+        ShiftSwapRequest request = new ShiftSwapRequest(99L, 200L, null, null);
+
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(requester));
+        when(shiftAssignmentRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> shiftSwapService.requestSwap(1L, request))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void approveSwap_TwoWaySwap_NoConflicts_ReassignsBothAndNotifies() {
+        ShiftSwap swap = ShiftSwap.builder()
+                .id(10L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(targetAssignment)
+                .status(ShiftSwapStatus.PENDING_MANAGER_APPROVAL).build();
+
+        when(userRepository.findById(3L)).thenReturn(Optional.of(managerUser));
+        when(shiftSwapRepository.findByIdWithDetails(10L)).thenReturn(Optional.of(swap));
+        when(shiftAssignmentRepository.existsConflictExcluding(any(), any(), any(), any(), any())).thenReturn(false);
+        when(leaveRequestRepository.existsOverlappingByEmployeeAndStatuses(any(), any(), any(), any())).thenReturn(false);
+
+        shiftSwapService.approveSwap(3L, 10L);
+
+        assertThat(swap.getStatus()).isEqualTo(ShiftSwapStatus.APPROVED);
+        assertThat(swap.getReviewedBy()).isEqualTo(managerUser);
+        assertThat(requesterAssignment.getEmployee()).isEqualTo(targetEmployee);
+        assertThat(targetAssignment.getEmployee()).isEqualTo(requester);
+        verify(notificationService, times(2)).notifyUser(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void approveSwap_ConflictDetected_ThrowsInvalidState() {
+        ShiftSwap swap = ShiftSwap.builder()
+                .id(10L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(targetAssignment)
+                .status(ShiftSwapStatus.PENDING_MANAGER_APPROVAL).build();
+
+        when(userRepository.findById(3L)).thenReturn(Optional.of(managerUser));
+        when(shiftSwapRepository.findByIdWithDetails(10L)).thenReturn(Optional.of(swap));
+        when(shiftAssignmentRepository.existsConflictExcluding(any(), any(), any(), any(), any())).thenReturn(true);
+
+        assertThatThrownBy(() -> shiftSwapService.approveSwap(3L, 10L))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessageContaining("Conflict detected");
+
+        assertThat(swap.getStatus()).isEqualTo(ShiftSwapStatus.PENDING_MANAGER_APPROVAL);
+    }
+
+    @Test
+    void approveSwap_NotPending_ThrowsInvalidState() {
+        ShiftSwap swap = ShiftSwap.builder()
+                .id(10L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(null)
+                .status(ShiftSwapStatus.APPROVED).build();
+
+        when(userRepository.findById(3L)).thenReturn(Optional.of(managerUser));
+        when(shiftSwapRepository.findByIdWithDetails(10L)).thenReturn(Optional.of(swap));
+
+        assertThatThrownBy(() -> shiftSwapService.approveSwap(3L, 10L))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Swap request is not pending approval");
+    }
+
+    @Test
+    void approveSwap_LeaveConflictOnApproval_ThrowsInvalidState() {
+        ShiftSwap swap = ShiftSwap.builder()
+                .id(10L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(null)
+                .status(ShiftSwapStatus.PENDING_MANAGER_APPROVAL).build();
+
+        when(userRepository.findById(3L)).thenReturn(Optional.of(managerUser));
+        when(shiftSwapRepository.findByIdWithDetails(10L)).thenReturn(Optional.of(swap));
+        when(shiftAssignmentRepository.existsConflictExcluding(any(), any(), any(), any(), any())).thenReturn(false);
+        when(leaveRequestRepository.existsOverlappingByEmployeeAndStatuses(
+                eq(200L), any(), any(), eq(List.of(LeaveStatus.APPROVED)))).thenReturn(true);
+
+        assertThatThrownBy(() -> shiftSwapService.approveSwap(3L, 10L))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessageContaining("approved leave");
+    }
+
+    @Test
+    void rejectSwap_ValidRequest_SetsRejectedAndNotifiesBoth() {
+        ShiftSwap swap = ShiftSwap.builder()
+                .id(10L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(null)
+                .status(ShiftSwapStatus.PENDING_MANAGER_APPROVAL).build();
+
+        when(userRepository.findById(3L)).thenReturn(Optional.of(managerUser));
+        when(shiftSwapRepository.findByIdWithDetails(10L)).thenReturn(Optional.of(swap));
+
+        shiftSwapService.rejectSwap(3L, 10L, "Insufficient staff coverage");
+
+        assertThat(swap.getStatus()).isEqualTo(ShiftSwapStatus.REJECTED);
+        assertThat(swap.getManagerNote()).isEqualTo("Insufficient staff coverage");
+        assertThat(swap.getReviewedBy()).isEqualTo(managerUser);
+        verify(notificationService, times(2)).notifyUser(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void rejectSwap_NotPending_ThrowsInvalidState() {
+        ShiftSwap swap = ShiftSwap.builder()
+                .id(10L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(null)
+                .status(ShiftSwapStatus.REJECTED).build();
+
+        when(userRepository.findById(3L)).thenReturn(Optional.of(managerUser));
+        when(shiftSwapRepository.findByIdWithDetails(10L)).thenReturn(Optional.of(swap));
+
+        assertThatThrownBy(() -> shiftSwapService.rejectSwap(3L, 10L, null))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Swap request is not pending approval");
+    }
+}


### PR DESCRIPTION
## What

Implements the full shift scheduling epic (US-SHIFT-01 through US-SHIFT-08):

- **US-SHIFT-01** — Create a shift (`POST /api/v1/shifts`)
- **US-SHIFT-02** — Assign an employee to a shift with a four-stage conflict pipeline (`POST /api/v1/shifts/{id}/assignments`)
- **US-SHIFT-03** — Remove an employee from a shift (`DELETE /api/v1/shifts/{id}/assignments/{employeeId}`)
- **US-SHIFT-04** — Cancel a shift and notify all assignees (`PATCH /api/v1/shifts/{id}/cancel`)
- **US-SHIFT-05** — View my upcoming shifts as an employee (`GET /api/v1/employees/me/shifts`)
- **US-SHIFT-06** — View a paginated location shift schedule with staffing status and caching (`GET /api/v1/locations/{id}/shifts`)
- **US-SHIFT-07** — Request a shift swap with a colleague (`POST /api/v1/shift-swaps`)
- **US-SHIFT-08** — Approve or reject a shift swap with atomic reassignment and conflict re-validation (`PATCH /api/v1/shift-swaps/{id}/approve|reject`)

## Why

Managers and employees need end-to-end control over shift coverage. Employees must be able to see their schedule and coordinate swaps without leaving shifts uncovered. Managers need tools to create shifts, control who is assigned, cancel shifts when needed, and retain final approval over swap requests. These stories satisfy FR-SHIFT-01 through FR-SHIFT-08 and are the core deliverable of Epic 6.

## How to test

### Create & assign (US-SHIFT-01, US-SHIFT-02)

1. Log in as MANAGER. Call `POST /api/v1/shifts` with a valid location and department — expect 201.
2. Repeat as MANAGER for a location you are not assigned to — expect 403.
3. Log in as HR_ADMIN and create a shift for any location — expect 201.
4. As MANAGER, assign an employee to the shift via `POST /api/v1/shifts/{id}/assignments` — expect 201 and a `SHIFT_ASSIGNED` notification in the employee's inbox.
5. Assign the same employee to an overlapping shift — expect 409 (double-booking).
6. Assign an employee who has an approved leave on the shift date — expect 409 (leave overlap).
7. Assign an employee outside their declared availability — expect 200 with `WARNING` and `AVAILABILITY_MISMATCH`; re-submit with `?override=true` — expect 201.
8. Assign an employee who would exceed their contracted weekly hours — expect 200 with `WARNING` and `OVERTIME_RISK`.

### Remove & cancel (US-SHIFT-03, US-SHIFT-04)

1. Call `DELETE /api/v1/shifts/{id}/assignments/{employeeId}` as MANAGER — expect 204 and a `SHIFT_REMOVED` notification.
2. Call `PATCH /api/v1/shifts/{id}/cancel` — expect 204 and a `SHIFT_CANCELLED` notification for every assigned employee.
3. Cancel the same shift again — expect 409.

### View shifts (US-SHIFT-05, US-SHIFT-06)

1. Log in as EMPLOYEE, call `GET /api/v1/employees/me/shifts` — expect only OPEN shifts; add `?include=cancelled` — expect cancelled shifts included. Verify colleagues list is populated.
2. As MANAGER, call `GET /api/v1/locations/{id}/shifts` — expect a paginated schedule with `staffingStatus` set correctly (`UNDERSTAFFED` when assigned count < minimum headcount).
3. Call the same endpoint twice — the second response should be served from cache. Assign an employee to any shift, then call again — cache should be cleared and fresh data returned.

### Shift swaps (US-SHIFT-07, US-SHIFT-08)

1. Log in as EMPLOYEE, call `POST /api/v1/shift-swaps` with your own `myShiftAssignmentId` — expect 201 with `PENDING_MANAGER_APPROVAL`. Verify the target employee receives a notification.
2. Call the same endpoint with a `myShiftAssignmentId` that belongs to a different employee — expect 400.
3. Log in as MANAGER, call `PATCH /api/v1/shift-swaps/{id}/approve` — expect 204. Verify both `ShiftAssignment` records are reassigned and both employees receive notifications.
4. Create a swap where the target employee has an approved leave on the requester's shift date. Attempt to approve — expect 409 with a conflict detail and no reassignment.
5. Call `PATCH /api/v1/shift-swaps/{id}/approve` on an already-approved swap — expect 409.
6. Call `PATCH /api/v1/shift-swaps/{id}/reject` with an optional `managerNote` — expect 204. Verify both employees receive rejection notifications.

## Notes

- **Notifications are synchronous, not async.** The user stories describe "async notifications", but the existing `NotificationService` is a synchronous, in-process service. All notifications are fired within the same transaction as the mutation. A true async implementation (e.g. Spring Events or a message broker) is out of scope for this epic and would be a separate infrastructure concern.

- **Swap proposal reuses `SWAP_OUTCOME` notification type.** There is no dedicated `SWAP_PROPOSED` value in the `NotificationType` enum. The initial proposal notification to the target employee reuses `SWAP_OUTCOME`. A new enum value could be added later if inbox filtering requires distinguishing proposals from outcomes.

- **In-memory pagination for US-SHIFT-06.** JPA does not support `LIMIT`/`OFFSET` combined with `join fetch` without triggering a `HHH90003004` in-memory pagination warning. To avoid this, `getLocationShifts` loads all shifts for the location and date range, applies the optional department filter and pagination in Java, then batch-fetches assignees for the current page only. This is acceptable given the bounded size of a weekly shift schedule per location.

- **`existsConflictExcluding` for swap approval.** The existing `existsOverlappingAssignment` query excludes only one shift ID. For a two-way swap, both swapped assignments must be excluded to avoid false positives. A new `existsConflictExcluding(employeeId, excludedShiftIds, ...)` query accepting a list of excluded IDs was added to `ShiftAssignmentRepository`.

- **Liquibase master file corrected.** The changelog master contained a broken reference to `005-leave-request-updates.xml`; the actual file on disk is `004-leave-request-updates.xml`. This was corrected as part of this PR to allow the new `005-add-shift-swap-table.xml` migration to apply cleanly.

- **Cache eviction uses `allEntries = true`.** All location-shift cache entries are cleared on any shift mutation (create, cancel, assign, remove, swap approve/reject). This is intentionally broad for simplicity; a key-scoped eviction strategy can be added later if cache hit rates become a concern.

<img width="1830" height="747" alt="image" src="https://github.com/user-attachments/assets/310dda36-c259-4636-8046-9ed1edb38c62" />
