### PR TITLE
feature:  shift swap retrieval for SWAP-02 and SWAP-07.

### DIFF
--- a/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapController.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapController.java
@@ -5,6 +5,7 @@ import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.shift.dto.RejectSwapRequest;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapRequest;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
+import com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus;
 import com.shiftsync.shiftsync.shift.service.ShiftSwapService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,12 +19,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/shift-swaps")
@@ -33,6 +38,26 @@ public class ShiftSwapController {
 
     private final ShiftSwapService shiftSwapService;
     private final AuthenticationHelper authenticationHelper;
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('EMPLOYEE', 'MANAGER', 'HR_ADMIN')")
+    @Operation(
+            summary = "Retrieve shift swap requests",
+            description = "Employees see their own swaps (as requester or target), optionally filtered by status. Managers see pending swaps for their location. HR Admins see all pending swaps."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Swaps returned", content = @Content(schema = @Schema(implementation = ShiftSwapResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "User or employee profile not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<List<ShiftSwapResponse>> getMySwaps(
+            Authentication authentication,
+            @RequestParam(required = false) ShiftSwapStatus status
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        return ResponseEntity.ok(shiftSwapService.getMySwaps(actorUserId, status));
+    }
 
     @PostMapping
     @PreAuthorize("hasRole('EMPLOYEE')")

--- a/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapController.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapController.java
@@ -15,6 +15,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -27,8 +30,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/shift-swaps")
@@ -43,7 +44,10 @@ public class ShiftSwapController {
     @PreAuthorize("hasAnyRole('EMPLOYEE', 'MANAGER', 'HR_ADMIN')")
     @Operation(
             summary = "Retrieve shift swap requests",
-            description = "Employees see their own swaps (as requester or target), optionally filtered by status. Managers see pending swaps for their location. HR Admins see all pending swaps."
+            description = "Returns a paginated list of shift swap requests scoped to the caller's role. " +
+                    "EMPLOYEE: their own swaps as requester or target (status filter honoured). " +
+                    "MANAGER: pending swaps for their assigned location(s) (status filter ignored). " +
+                    "HR_ADMIN: all pending swaps system-wide (status filter ignored)."
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Swaps returned", content = @Content(schema = @Schema(implementation = ShiftSwapResponse.class))),
@@ -51,12 +55,13 @@ public class ShiftSwapController {
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "User or employee profile not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<List<ShiftSwapResponse>> getMySwaps(
+    public ResponseEntity<Page<ShiftSwapResponse>> getMySwaps(
             Authentication authentication,
-            @RequestParam(required = false) ShiftSwapStatus status
+            @RequestParam(required = false) ShiftSwapStatus status,
+            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable
     ) {
         Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
-        return ResponseEntity.ok(shiftSwapService.getMySwaps(actorUserId, status));
+        return ResponseEntity.ok(shiftSwapService.getMySwaps(actorUserId, status, pageable));
     }
 
     @PostMapping

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftSwapRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftSwapRepository.java
@@ -1,16 +1,27 @@
 package com.shiftsync.shiftsync.shift.repository;
 
 import com.shiftsync.shiftsync.shift.entity.ShiftSwap;
+import com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
+/**
+ * The interface Shift swap repository.
+ */
 @Repository
 public interface ShiftSwapRepository extends JpaRepository<ShiftSwap, Long> {
 
+    /**
+     * Find by id with details optional.
+     *
+     * @param id the id
+     * @return the optional
+     */
     @Query("""
             select sw
             from ShiftSwap sw
@@ -25,4 +36,72 @@ public interface ShiftSwapRepository extends JpaRepository<ShiftSwap, Long> {
             where sw.id = :id
             """)
     Optional<ShiftSwap> findByIdWithDetails(@Param("id") Long id);
+
+    /**
+     * Find by participant list.
+     *
+     * @param employeeId the employee id
+     * @param status     the status
+     * @return the list
+     */
+    @Query("""
+            select sw
+            from ShiftSwap sw
+            join fetch sw.requester req
+            join fetch req.user
+            join fetch sw.requesterAssignment ra
+            join fetch ra.shift
+            join fetch sw.targetEmployee te
+            join fetch te.user
+            left join fetch sw.targetAssignment ta
+            left join fetch ta.shift
+            where (sw.requester.id = :employeeId or sw.targetEmployee.id = :employeeId)
+              and (:status is null or sw.status = :status)
+            order by sw.createdAt desc
+            """)
+    List<ShiftSwap> findByParticipant(@Param("employeeId") Long employeeId, @Param("status") ShiftSwapStatus status);
+
+    /**
+     * Find pending by location ids list.
+     *
+     * @param locationIds the location ids
+     * @return the list
+     */
+    @Query("""
+            select sw
+            from ShiftSwap sw
+            join fetch sw.requester req
+            join fetch req.user
+            join fetch sw.requesterAssignment ra
+            join fetch ra.shift raShift
+            join fetch sw.targetEmployee te
+            join fetch te.user
+            left join fetch sw.targetAssignment ta
+            left join fetch ta.shift
+            where sw.status = com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus.PENDING_MANAGER_APPROVAL
+              and raShift.location.id in :locationIds
+            order by sw.createdAt asc
+            """)
+    List<ShiftSwap> findPendingByLocationIds(@Param("locationIds") List<Long> locationIds);
+
+    /**
+     * Find all pending list.
+     *
+     * @return the list
+     */
+    @Query("""
+            select sw
+            from ShiftSwap sw
+            join fetch sw.requester req
+            join fetch req.user
+            join fetch sw.requesterAssignment ra
+            join fetch ra.shift
+            join fetch sw.targetEmployee te
+            join fetch te.user
+            left join fetch sw.targetAssignment ta
+            left join fetch ta.shift
+            where sw.status = com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus.PENDING_MANAGER_APPROVAL
+            order by sw.createdAt asc
+            """)
+    List<ShiftSwap> findAllPending();
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftSwapRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftSwapRepository.java
@@ -2,6 +2,8 @@ package com.shiftsync.shiftsync.shift.repository;
 
 import com.shiftsync.shiftsync.shift.entity.ShiftSwap;
 import com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -44,22 +46,24 @@ public interface ShiftSwapRepository extends JpaRepository<ShiftSwap, Long> {
      * @param status     the status
      * @return the list
      */
-    @Query("""
-            select sw
-            from ShiftSwap sw
-            join fetch sw.requester req
-            join fetch req.user
-            join fetch sw.requesterAssignment ra
-            join fetch ra.shift
-            join fetch sw.targetEmployee te
-            join fetch te.user
-            left join fetch sw.targetAssignment ta
-            left join fetch ta.shift
-            where (sw.requester.id = :employeeId or sw.targetEmployee.id = :employeeId)
-              and (:status is null or sw.status = :status)
-            order by sw.createdAt desc
-            """)
-    List<ShiftSwap> findByParticipant(@Param("employeeId") Long employeeId, @Param("status") ShiftSwapStatus status);
+    @Query(
+            value = """
+                    select sw from ShiftSwap sw
+                    join fetch sw.requester req join fetch req.user
+                    join fetch sw.requesterAssignment ra join fetch ra.shift
+                    join fetch sw.targetEmployee te join fetch te.user
+                    left join fetch sw.targetAssignment ta left join fetch ta.shift
+                    where (sw.requester.id = :employeeId or sw.targetEmployee.id = :employeeId)
+                      and (:status is null or sw.status = :status)
+                    order by sw.createdAt desc
+                    """,
+            countQuery = """
+                    select count(sw) from ShiftSwap sw
+                    where (sw.requester.id = :employeeId or sw.targetEmployee.id = :employeeId)
+                      and (:status is null or sw.status = :status)
+                    """
+    )
+    Page<ShiftSwap> findByParticipant(@Param("employeeId") Long employeeId, @Param("status") ShiftSwapStatus status, Pageable pageable);
 
     /**
      * Find pending by location ids list.
@@ -67,41 +71,45 @@ public interface ShiftSwapRepository extends JpaRepository<ShiftSwap, Long> {
      * @param locationIds the location ids
      * @return the list
      */
-    @Query("""
-            select sw
-            from ShiftSwap sw
-            join fetch sw.requester req
-            join fetch req.user
-            join fetch sw.requesterAssignment ra
-            join fetch ra.shift raShift
-            join fetch sw.targetEmployee te
-            join fetch te.user
-            left join fetch sw.targetAssignment ta
-            left join fetch ta.shift
-            where sw.status = com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus.PENDING_MANAGER_APPROVAL
-              and raShift.location.id in :locationIds
-            order by sw.createdAt asc
-            """)
-    List<ShiftSwap> findPendingByLocationIds(@Param("locationIds") List<Long> locationIds);
+    @Query(
+            value = """
+                    select sw from ShiftSwap sw
+                    join fetch sw.requester req join fetch req.user
+                    join fetch sw.requesterAssignment ra join fetch ra.shift raShift
+                    join fetch sw.targetEmployee te join fetch te.user
+                    left join fetch sw.targetAssignment ta left join fetch ta.shift
+                    where sw.status = com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus.PENDING_MANAGER_APPROVAL
+                      and raShift.location.id in :locationIds
+                    order by sw.createdAt asc
+                    """,
+            countQuery = """
+                    select count(sw) from ShiftSwap sw
+                    join sw.requesterAssignment ra join ra.shift raShift
+                    where sw.status = com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus.PENDING_MANAGER_APPROVAL
+                      and raShift.location.id in :locationIds
+                    """
+    )
+    Page<ShiftSwap> findPendingByLocationIds(@Param("locationIds") List<Long> locationIds, Pageable pageable);
 
     /**
      * Find all pending list.
      *
      * @return the list
      */
-    @Query("""
-            select sw
-            from ShiftSwap sw
-            join fetch sw.requester req
-            join fetch req.user
-            join fetch sw.requesterAssignment ra
-            join fetch ra.shift
-            join fetch sw.targetEmployee te
-            join fetch te.user
-            left join fetch sw.targetAssignment ta
-            left join fetch ta.shift
-            where sw.status = com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus.PENDING_MANAGER_APPROVAL
-            order by sw.createdAt asc
-            """)
-    List<ShiftSwap> findAllPending();
+    @Query(
+            value = """
+                    select sw from ShiftSwap sw
+                    join fetch sw.requester req join fetch req.user
+                    join fetch sw.requesterAssignment ra join fetch ra.shift
+                    join fetch sw.targetEmployee te join fetch te.user
+                    left join fetch sw.targetAssignment ta left join fetch ta.shift
+                    where sw.status = com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus.PENDING_MANAGER_APPROVAL
+                    order by sw.createdAt asc
+                    """,
+            countQuery = """
+                    select count(sw) from ShiftSwap sw
+                    where sw.status = com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus.PENDING_MANAGER_APPROVAL
+                    """
+    )
+    Page<ShiftSwap> findAllPending(Pageable pageable);
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftSwapService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftSwapService.java
@@ -2,12 +2,47 @@ package com.shiftsync.shiftsync.shift.service;
 
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapRequest;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
+import com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus;
 
+import java.util.List;
+
+/**
+ * The interface Shift swap service.
+ */
 public interface ShiftSwapService {
 
+    /**
+     * Request swap shift swap response.
+     *
+     * @param actorUserId the actor user id
+     * @param request     the request
+     * @return the shift swap response
+     */
     ShiftSwapResponse requestSwap(Long actorUserId, ShiftSwapRequest request);
 
+    /**
+     * Approve swap.
+     *
+     * @param actorUserId the actor user id
+     * @param swapId      the swap id
+     */
     void approveSwap(Long actorUserId, Long swapId);
 
+    /**
+     * Reject swap.
+     *
+     * @param actorUserId the actor user id
+     * @param swapId      the swap id
+     * @param managerNote the manager note
+     */
     void rejectSwap(Long actorUserId, Long swapId, String managerNote);
+
+    /**
+     * Gets my swaps.
+     *
+     * @param actorUserId the actor user id
+     * @param status      the status
+     * @return the my swaps
+     */
+    List<ShiftSwapResponse> getMySwaps(Long actorUserId, ShiftSwapStatus status);
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftSwapService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftSwapService.java
@@ -3,8 +3,8 @@ package com.shiftsync.shiftsync.shift.service;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapRequest;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
 import com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * The interface Shift swap service.
@@ -44,5 +44,5 @@ public interface ShiftSwapService {
      * @param status      the status
      * @return the my swaps
      */
-    List<ShiftSwapResponse> getMySwaps(Long actorUserId, ShiftSwapStatus status);
+    Page<ShiftSwapResponse> getMySwaps(Long actorUserId, ShiftSwapStatus status, Pageable pageable);
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftSwapServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftSwapServiceImpl.java
@@ -6,18 +6,20 @@ import com.shiftsync.shiftsync.common.enums.LeaveStatus;
 import com.shiftsync.shiftsync.common.enums.NotificationType;
 import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.common.exception.InvalidStateException;
+import com.shiftsync.shiftsync.common.enums.UserRole;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.config.CacheConfig;
 import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
 import com.shiftsync.shiftsync.notification.service.NotificationService;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapRequest;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
+import com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus;
 import com.shiftsync.shiftsync.shift.entity.Shift;
 import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
 import com.shiftsync.shiftsync.shift.entity.ShiftSwap;
-import com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus;
 import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
 import com.shiftsync.shiftsync.shift.repository.ShiftSwapRepository;
 import com.shiftsync.shiftsync.shift.service.ShiftSwapService;
@@ -28,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +42,7 @@ public class ShiftSwapServiceImpl implements ShiftSwapService {
     private final ShiftSwapRepository shiftSwapRepository;
     private final LeaveRequestRepository leaveRequestRepository;
     private final NotificationService notificationService;
+    private final ManagerLocationRepository managerLocationRepository;
 
     @Override
     @Transactional
@@ -208,6 +212,31 @@ public class ShiftSwapServiceImpl implements ShiftSwapService {
                 "SHIFT_SWAP",
                 swapId
         );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ShiftSwapResponse> getMySwaps(Long actorUserId, ShiftSwapStatus status) {
+        User actor = userRepository.findById(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        if (actor.getRole() == UserRole.HR_ADMIN) {
+            return shiftSwapRepository.findAllPending()
+                    .stream().map(this::toResponse).collect(Collectors.toList());
+        }
+
+        if (actor.getRole() == UserRole.MANAGER) {
+            Employee manager = employeeRepository.findByUserId(actorUserId)
+                    .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
+            List<Long> locationIds = managerLocationRepository.findLocationIdsByManagerEmployeeId(manager.getId());
+            return shiftSwapRepository.findPendingByLocationIds(locationIds)
+                    .stream().map(this::toResponse).collect(Collectors.toList());
+        }
+
+        Employee employee = employeeRepository.findByUserId(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
+        return shiftSwapRepository.findByParticipant(employee.getId(), status)
+                .stream().map(this::toResponse).collect(Collectors.toList());
     }
 
     private void checkConflictsForApproval(Employee employee, Shift newShift, List<Long> excludedShiftIds) {

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftSwapServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftSwapServiceImpl.java
@@ -25,12 +25,12 @@ import com.shiftsync.shiftsync.shift.repository.ShiftSwapRepository;
 import com.shiftsync.shiftsync.shift.service.ShiftSwapService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -120,11 +120,9 @@ public class ShiftSwapServiceImpl implements ShiftSwapService {
         Employee targetEmployee = swap.getTargetEmployee();
         Shift requesterShift = requesterAssignment.getShift();
 
-        List<Long> excludedShiftIds = new ArrayList<>();
-        excludedShiftIds.add(requesterShift.getId());
-        if (targetAssignment != null) {
-            excludedShiftIds.add(targetAssignment.getShift().getId());
-        }
+        List<Long> excludedShiftIds = targetAssignment != null
+                ? List.of(requesterShift.getId(), targetAssignment.getShift().getId())
+                : List.of(requesterShift.getId());
 
         checkConflictsForApproval(targetEmployee, requesterShift, excludedShiftIds);
 
@@ -216,27 +214,24 @@ public class ShiftSwapServiceImpl implements ShiftSwapService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<ShiftSwapResponse> getMySwaps(Long actorUserId, ShiftSwapStatus status) {
+    public Page<ShiftSwapResponse> getMySwaps(Long actorUserId, ShiftSwapStatus status, Pageable pageable) {
         User actor = userRepository.findById(actorUserId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
         if (actor.getRole() == UserRole.HR_ADMIN) {
-            return shiftSwapRepository.findAllPending()
-                    .stream().map(this::toResponse).collect(Collectors.toList());
+            return shiftSwapRepository.findAllPending(pageable).map(this::toResponse);
         }
 
         if (actor.getRole() == UserRole.MANAGER) {
             Employee manager = employeeRepository.findByUserId(actorUserId)
                     .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
             List<Long> locationIds = managerLocationRepository.findLocationIdsByManagerEmployeeId(manager.getId());
-            return shiftSwapRepository.findPendingByLocationIds(locationIds)
-                    .stream().map(this::toResponse).collect(Collectors.toList());
+            return shiftSwapRepository.findPendingByLocationIds(locationIds, pageable).map(this::toResponse);
         }
 
         Employee employee = employeeRepository.findByUserId(actorUserId)
                 .orElseThrow(() -> new ResourceNotFoundException("Employee profile not found"));
-        return shiftSwapRepository.findByParticipant(employee.getId(), status)
-                .stream().map(this::toResponse).collect(Collectors.toList());
+        return shiftSwapRepository.findByParticipant(employee.getId(), status, pageable).map(this::toResponse);
     }
 
     private void checkConflictsForApproval(Employee employee, Shift newShift, List<Long> excludedShiftIds) {

--- a/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapControllerWebMvcTest.java
@@ -9,6 +9,7 @@ import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
 import com.shiftsync.shiftsync.config.security.JwtService;
 import com.shiftsync.shiftsync.config.security.SecurityConfig;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
+import com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus;
 import com.shiftsync.shiftsync.shift.service.ShiftSwapService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,12 +24,15 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -188,5 +192,54 @@ class ShiftSwapControllerWebMvcTest {
 
         mockMvc.perform(patch("/api/v1/shift-swaps/10/reject"))
                 .andExpect(status().isConflict());
+    }
+
+    @Test
+    void getMySwaps_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/shift-swaps"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "EMPLOYEE")
+    void getMySwaps_AsEmployee_NoFilter_ReturnsOk() throws Exception {
+        ShiftSwapResponse response = new ShiftSwapResponse(
+                10L, 100L, "Alice",
+                LocalDate.of(2026, 6, 1), LocalTime.of(9, 0), LocalTime.of(17, 0),
+                200L, "Bob", null, null, null,
+                "PENDING_MANAGER_APPROVAL", null, null, LocalDateTime.now()
+        );
+        when(shiftSwapService.getMySwaps(anyLong(), isNull())).thenReturn(List.of(response));
+
+        mockMvc.perform(get("/api/v1/shift-swaps"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(10))
+                .andExpect(jsonPath("$[0].requesterName").value("Alice"))
+                .andExpect(jsonPath("$[0].status").value("PENDING_MANAGER_APPROVAL"));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "EMPLOYEE")
+    void getMySwaps_AsEmployee_WithStatusFilter_ReturnsOk() throws Exception {
+        ShiftSwapResponse response = new ShiftSwapResponse(
+                11L, 100L, "Alice",
+                LocalDate.of(2026, 6, 1), LocalTime.of(9, 0), LocalTime.of(17, 0),
+                200L, "Bob", null, null, null,
+                "APPROVED", null, null, LocalDateTime.now()
+        );
+        when(shiftSwapService.getMySwaps(anyLong(), eq(ShiftSwapStatus.APPROVED))).thenReturn(List.of(response));
+
+        mockMvc.perform(get("/api/v1/shift-swaps").param("status", "APPROVED"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].status").value("APPROVED"));
+    }
+
+    @Test
+    @WithMockUser(username = "3", roles = "MANAGER")
+    void getMySwaps_AsManager_ReturnsOk() throws Exception {
+        when(shiftSwapService.getMySwaps(anyLong(), isNull())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/shift-swaps"))
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftSwapControllerWebMvcTest.java
@@ -26,6 +26,9 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -209,13 +212,14 @@ class ShiftSwapControllerWebMvcTest {
                 200L, "Bob", null, null, null,
                 "PENDING_MANAGER_APPROVAL", null, null, LocalDateTime.now()
         );
-        when(shiftSwapService.getMySwaps(anyLong(), isNull())).thenReturn(List.of(response));
+        when(shiftSwapService.getMySwaps(anyLong(), isNull(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(response)));
 
         mockMvc.perform(get("/api/v1/shift-swaps"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id").value(10))
-                .andExpect(jsonPath("$[0].requesterName").value("Alice"))
-                .andExpect(jsonPath("$[0].status").value("PENDING_MANAGER_APPROVAL"));
+                .andExpect(jsonPath("$.content[0].id").value(10))
+                .andExpect(jsonPath("$.content[0].requesterName").value("Alice"))
+                .andExpect(jsonPath("$.content[0].status").value("PENDING_MANAGER_APPROVAL"));
     }
 
     @Test
@@ -227,19 +231,32 @@ class ShiftSwapControllerWebMvcTest {
                 200L, "Bob", null, null, null,
                 "APPROVED", null, null, LocalDateTime.now()
         );
-        when(shiftSwapService.getMySwaps(anyLong(), eq(ShiftSwapStatus.APPROVED))).thenReturn(List.of(response));
+        when(shiftSwapService.getMySwaps(anyLong(), eq(ShiftSwapStatus.APPROVED), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(response)));
 
         mockMvc.perform(get("/api/v1/shift-swaps").param("status", "APPROVED"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].status").value("APPROVED"));
+                .andExpect(jsonPath("$.content[0].status").value("APPROVED"));
     }
 
     @Test
     @WithMockUser(username = "3", roles = "MANAGER")
     void getMySwaps_AsManager_ReturnsOk() throws Exception {
-        when(shiftSwapService.getMySwaps(anyLong(), isNull())).thenReturn(List.of());
+        when(shiftSwapService.getMySwaps(anyLong(), isNull(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
 
         mockMvc.perform(get("/api/v1/shift-swaps"))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "4", roles = "HR_ADMIN")
+    void getMySwaps_AsHrAdmin_ReturnsOk() throws Exception {
+        when(shiftSwapService.getMySwaps(anyLong(), isNull(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/v1/shift-swaps"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0));
     }
 }

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftSwapServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftSwapServiceImplTest.java
@@ -12,6 +12,7 @@ import com.shiftsync.shiftsync.employee.entity.Employee;
 import com.shiftsync.shiftsync.employee.repository.EmployeeRepository;
 import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
 import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.location.repository.ManagerLocationRepository;
 import com.shiftsync.shiftsync.notification.service.NotificationService;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapRequest;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
@@ -54,6 +55,7 @@ class ShiftSwapServiceImplTest {
     @Mock private ShiftSwapRepository shiftSwapRepository;
     @Mock private LeaveRequestRepository leaveRequestRepository;
     @Mock private NotificationService notificationService;
+    @Mock private ManagerLocationRepository managerLocationRepository;
 
     @InjectMocks
     private ShiftSwapServiceImpl shiftSwapService;
@@ -284,5 +286,85 @@ class ShiftSwapServiceImplTest {
         assertThatThrownBy(() -> shiftSwapService.rejectSwap(3L, 10L, null))
                 .isInstanceOf(InvalidStateException.class)
                 .hasMessage("Swap request is not pending approval");
+    }
+
+    @Test
+    void getMySwaps_Employee_NoStatusFilter_ReturnsAllParticipantSwaps() {
+        User employeeUser = requester.getUser();
+        ShiftSwap swap = ShiftSwap.builder()
+                .id(10L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(targetAssignment)
+                .status(ShiftSwapStatus.PENDING_MANAGER_APPROVAL).build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(employeeUser));
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(requester));
+        when(shiftSwapRepository.findByParticipant(100L, null)).thenReturn(List.of(swap));
+
+        List<ShiftSwapResponse> result = shiftSwapService.getMySwaps(1L, null);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).id()).isEqualTo(10L);
+        assertThat(result.get(0).requesterName()).isEqualTo("Alice");
+        assertThat(result.get(0).status()).isEqualTo("PENDING_MANAGER_APPROVAL");
+    }
+
+    @Test
+    void getMySwaps_Employee_WithStatusFilter_ReturnsFilteredSwaps() {
+        User employeeUser = requester.getUser();
+        ShiftSwap approved = ShiftSwap.builder()
+                .id(11L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(targetAssignment)
+                .status(ShiftSwapStatus.APPROVED).build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(employeeUser));
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(requester));
+        when(shiftSwapRepository.findByParticipant(100L, ShiftSwapStatus.APPROVED)).thenReturn(List.of(approved));
+
+        List<ShiftSwapResponse> result = shiftSwapService.getMySwaps(1L, ShiftSwapStatus.APPROVED);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).status()).isEqualTo("APPROVED");
+    }
+
+    @Test
+    void getMySwaps_Manager_ReturnsPendingSwapsForLocation() {
+        ShiftSwap swap = ShiftSwap.builder()
+                .id(10L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(targetAssignment)
+                .status(ShiftSwapStatus.PENDING_MANAGER_APPROVAL).build();
+
+        Employee managerEmployee = Employee.builder()
+                .id(300L).user(managerUser)
+                .employmentType(EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("40.00"))
+                .hireDate(LocalDate.of(2025, 1, 1))
+                .active(true).notificationEnabled(true).build();
+
+        when(userRepository.findById(3L)).thenReturn(Optional.of(managerUser));
+        when(employeeRepository.findByUserId(3L)).thenReturn(Optional.of(managerEmployee));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(300L)).thenReturn(List.of(10L));
+        when(shiftSwapRepository.findPendingByLocationIds(List.of(10L))).thenReturn(List.of(swap));
+
+        List<ShiftSwapResponse> result = shiftSwapService.getMySwaps(3L, null);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).status()).isEqualTo("PENDING_MANAGER_APPROVAL");
+    }
+
+    @Test
+    void getMySwaps_HrAdmin_ReturnsAllPendingSwaps() {
+        User hrAdminUser = User.builder().id(4L).fullName("HR Admin").role(UserRole.HR_ADMIN).build();
+        ShiftSwap swap = ShiftSwap.builder()
+                .id(10L).requester(requester).requesterAssignment(requesterAssignment)
+                .targetEmployee(targetEmployee).targetAssignment(targetAssignment)
+                .status(ShiftSwapStatus.PENDING_MANAGER_APPROVAL).build();
+
+        when(userRepository.findById(4L)).thenReturn(Optional.of(hrAdminUser));
+        when(shiftSwapRepository.findAllPending()).thenReturn(List.of(swap));
+
+        List<ShiftSwapResponse> result = shiftSwapService.getMySwaps(4L, null);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).id()).isEqualTo(10L);
     }
 }

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftSwapServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftSwapServiceImplTest.java
@@ -37,10 +37,15 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -298,14 +303,15 @@ class ShiftSwapServiceImplTest {
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(employeeUser));
         when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(requester));
-        when(shiftSwapRepository.findByParticipant(100L, null)).thenReturn(List.of(swap));
+        when(shiftSwapRepository.findByParticipant(eq(100L), isNull(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(swap)));
 
-        List<ShiftSwapResponse> result = shiftSwapService.getMySwaps(1L, null);
+        Page<ShiftSwapResponse> result = shiftSwapService.getMySwaps(1L, null, Pageable.unpaged());
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).id()).isEqualTo(10L);
-        assertThat(result.get(0).requesterName()).isEqualTo("Alice");
-        assertThat(result.get(0).status()).isEqualTo("PENDING_MANAGER_APPROVAL");
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).id()).isEqualTo(10L);
+        assertThat(result.getContent().get(0).requesterName()).isEqualTo("Alice");
+        assertThat(result.getContent().get(0).status()).isEqualTo("PENDING_MANAGER_APPROVAL");
     }
 
     @Test
@@ -318,12 +324,13 @@ class ShiftSwapServiceImplTest {
 
         when(userRepository.findById(1L)).thenReturn(Optional.of(employeeUser));
         when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(requester));
-        when(shiftSwapRepository.findByParticipant(100L, ShiftSwapStatus.APPROVED)).thenReturn(List.of(approved));
+        when(shiftSwapRepository.findByParticipant(eq(100L), eq(ShiftSwapStatus.APPROVED), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(approved)));
 
-        List<ShiftSwapResponse> result = shiftSwapService.getMySwaps(1L, ShiftSwapStatus.APPROVED);
+        Page<ShiftSwapResponse> result = shiftSwapService.getMySwaps(1L, ShiftSwapStatus.APPROVED, Pageable.unpaged());
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).status()).isEqualTo("APPROVED");
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).status()).isEqualTo("APPROVED");
     }
 
     @Test
@@ -343,12 +350,13 @@ class ShiftSwapServiceImplTest {
         when(userRepository.findById(3L)).thenReturn(Optional.of(managerUser));
         when(employeeRepository.findByUserId(3L)).thenReturn(Optional.of(managerEmployee));
         when(managerLocationRepository.findLocationIdsByManagerEmployeeId(300L)).thenReturn(List.of(10L));
-        when(shiftSwapRepository.findPendingByLocationIds(List.of(10L))).thenReturn(List.of(swap));
+        when(shiftSwapRepository.findPendingByLocationIds(eq(List.of(10L)), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(swap)));
 
-        List<ShiftSwapResponse> result = shiftSwapService.getMySwaps(3L, null);
+        Page<ShiftSwapResponse> result = shiftSwapService.getMySwaps(3L, null, Pageable.unpaged());
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).status()).isEqualTo("PENDING_MANAGER_APPROVAL");
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).status()).isEqualTo("PENDING_MANAGER_APPROVAL");
     }
 
     @Test
@@ -360,11 +368,12 @@ class ShiftSwapServiceImplTest {
                 .status(ShiftSwapStatus.PENDING_MANAGER_APPROVAL).build();
 
         when(userRepository.findById(4L)).thenReturn(Optional.of(hrAdminUser));
-        when(shiftSwapRepository.findAllPending()).thenReturn(List.of(swap));
+        when(shiftSwapRepository.findAllPending(any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(swap)));
 
-        List<ShiftSwapResponse> result = shiftSwapService.getMySwaps(4L, null);
+        Page<ShiftSwapResponse> result = shiftSwapService.getMySwaps(4L, null, Pageable.unpaged());
 
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).id()).isEqualTo(10L);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).id()).isEqualTo(10L);
     }
 }


### PR DESCRIPTION
## What
Implements shift swap retrieval for SWAP-02 and SWAP-07.

Adds `GET /api/v1/shift-swaps` with an optional `?status` query parameter. Results are role-scoped:
- **EMPLOYEE** — sees swaps where they are the requester or target, filterable by status
- **MANAGER** — sees all `PENDING_MANAGER_APPROVAL` swaps for their assigned location(s)
- **HR_ADMIN** — sees all `PENDING_MANAGER_APPROVAL` swaps across all locations

## Why
SWAP-02 requires employees and managers to retrieve active swap requests. SWAP-07 requires employees to access their swap history (approved/rejected outcomes). Both are satisfied by a single endpoint using the `?status` filter:
- `GET /api/v1/shift-swaps?status=PENDING_MANAGER_APPROVAL` → active requests (SWAP-02)
- `GET /api/v1/shift-swaps?status=APPROVED` or `?status=REJECTED` → history (SWAP-07)
- `GET /api/v1/shift-swaps` → all, no filter

## How to test
1. Log in as **EMPLOYEE**, submit a swap request via `POST /api/v1/shift-swaps`
2. Call `GET /api/v1/shift-swaps` — expect the pending swap to appear
3. Call `GET /api/v1/shift-swaps?status=PENDING_MANAGER_APPROVAL` — expect the same result
4. Call `GET /api/v1/shift-swaps?status=APPROVED` — expect an empty list (not yet approved)
5. Log in as **MANAGER**, call `GET /api/v1/shift-swaps` — expect only pending swaps for their location
6. Log in as **HR_ADMIN**, call `GET /api/v1/shift-swaps` — expect all pending swaps across all locations
7. Approve the swap via `PATCH /api/v1/shift-swaps/{id}/approve`, then call `GET /api/v1/shift-swaps?status=APPROVED` as the employee — expect the approved swap to appear (SWAP-07)

## Notes
- The `?status` filter is only applied for the EMPLOYEE role. Manager and HR Admin responses are always scoped to `PENDING_MANAGER_APPROVAL` regardless of the param — managers need a decision queue, not a history view.
- Three dedicated repository queries with join fetches are used (`findByParticipant`, `findPendingByLocationIds`, `findAllPending`) to avoid N+1 queries on the response mapping.
- Swap history for managers (approved/rejected swaps they reviewed) is not in scope for these two stories and can be added as a follow-up.

<img width="1438" height="471" alt="image" src="https://github.com/user-attachments/assets/2e00bef2-6c35-4f9d-9924-f6019f36b88c" />
