### PR TITLE
Add shift swap and notification retrieval endpoints with tests

### DIFF
--- a/src/main/java/com/shiftsync/shiftsync/config/AsyncConfig.java
+++ b/src/main/java/com/shiftsync/shiftsync/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.shiftsync.shiftsync.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "notificationExecutor")
+    public Executor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("notification-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/config/AsyncConfig.java
+++ b/src/main/java/com/shiftsync/shiftsync/config/AsyncConfig.java
@@ -1,7 +1,11 @@
 package com.shiftsync.shiftsync.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -9,7 +13,9 @@ import java.util.concurrent.Executor;
 
 @Configuration
 @EnableAsync
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
+
+    private static final Logger log = LoggerFactory.getLogger(AsyncConfig.class);
 
     @Bean(name = "notificationExecutor")
     public Executor notificationExecutor() {
@@ -20,5 +26,13 @@ public class AsyncConfig {
         executor.setThreadNamePrefix("notification-");
         executor.initialize();
         return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) -> log.error(
+                "Async method '{}' failed with args {}: {}",
+                method.getName(), params, ex.getMessage(), ex
+        );
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/notification/controller/NotificationController.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/controller/NotificationController.java
@@ -1,0 +1,92 @@
+package com.shiftsync.shiftsync.notification.controller;
+
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.notification.dto.NotificationResponse;
+import com.shiftsync.shiftsync.notification.dto.UnreadCountResponse;
+import com.shiftsync.shiftsync.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+@Tag(name = "Notifications", description = "User notification inbox endpoints")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final AuthenticationHelper authenticationHelper;
+
+    @GetMapping
+    @Operation(
+            summary = "Get notification inbox",
+            description = "Returns paginated notifications for the authenticated user. Pass unreadOnly=true to filter unread only."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Notifications returned"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Page<NotificationResponse>> getInbox(
+            Authentication authentication,
+            @RequestParam(defaultValue = "false") boolean unreadOnly,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        return ResponseEntity.ok(notificationService.getInbox(actorUserId, unreadOnly, page, size));
+    }
+
+    @GetMapping("/unread-count")
+    @Operation(summary = "Get unread notification count")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Count returned"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<UnreadCountResponse> getUnreadCount(Authentication authentication) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        return ResponseEntity.ok(notificationService.getUnreadCount(actorUserId));
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    @Operation(summary = "Mark a notification as read")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Marked as read"),
+            @ApiResponse(responseCode = "400", description = "Notification belongs to another user", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Notification not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> markAsRead(
+            Authentication authentication,
+            @PathVariable Long notificationId
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        notificationService.markAsRead(actorUserId, notificationId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/read-all")
+    @Operation(summary = "Mark all notifications as read")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "All notifications marked as read"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> markAllAsRead(Authentication authentication) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        notificationService.markAllAsRead(actorUserId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/notification/controller/NotificationController.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/controller/NotificationController.java
@@ -34,7 +34,7 @@ public class NotificationController {
     @GetMapping
     @Operation(
             summary = "Get notification inbox",
-            description = "Returns paginated notifications for the authenticated user. Pass unreadOnly=true to filter unread only."
+            description = "Returns paginated notifications for the authenticated user. Pass ?read=false to filter unread notifications only."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Notifications returned"),
@@ -42,12 +42,12 @@ public class NotificationController {
     })
     public ResponseEntity<Page<NotificationResponse>> getInbox(
             Authentication authentication,
-            @RequestParam(defaultValue = "false") boolean unreadOnly,
+            @RequestParam(required = false) Boolean read,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size
     ) {
         Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
-        return ResponseEntity.ok(notificationService.getInbox(actorUserId, unreadOnly, page, size));
+        return ResponseEntity.ok(notificationService.getInbox(actorUserId, read, page, size));
     }
 
     @GetMapping("/unread-count")
@@ -65,8 +65,8 @@ public class NotificationController {
     @Operation(summary = "Mark a notification as read")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "Marked as read"),
-            @ApiResponse(responseCode = "400", description = "Notification belongs to another user", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Notification belongs to another user", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "Notification not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<Void> markAsRead(

--- a/src/main/java/com/shiftsync/shiftsync/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/dto/NotificationResponse.java
@@ -1,0 +1,16 @@
+package com.shiftsync.shiftsync.notification.dto;
+
+import com.shiftsync.shiftsync.common.enums.NotificationType;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+        Long id,
+        NotificationType type,
+        String message,
+        String entityType,
+        Long entityId,
+        boolean read,
+        LocalDateTime readAt,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/shiftsync/shiftsync/notification/dto/UnreadCountResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/dto/UnreadCountResponse.java
@@ -1,0 +1,3 @@
+package com.shiftsync.shiftsync.notification.dto;
+
+public record UnreadCountResponse(long count) {}

--- a/src/main/java/com/shiftsync/shiftsync/notification/entity/NotificationEvent.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/entity/NotificationEvent.java
@@ -1,0 +1,11 @@
+package com.shiftsync.shiftsync.notification.entity;
+
+import com.shiftsync.shiftsync.common.enums.NotificationType;
+
+public record NotificationEvent(
+        Long userId,
+        NotificationType type,
+        String message,
+        String entityType,
+        Long entityId
+) {}

--- a/src/main/java/com/shiftsync/shiftsync/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/repository/NotificationRepository.java
@@ -1,9 +1,55 @@
 package com.shiftsync.shiftsync.notification.repository;
 
 import com.shiftsync.shiftsync.notification.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+
+/**
+ * The interface Notification repository.
+ */
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    /**
+     * Find by user id order by created at desc page.
+     *
+     * @param userId   the user id
+     * @param pageable the pageable
+     * @return the page
+     */
+    Page<Notification> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    /**
+     * Find by user id and read false order by created at desc page.
+     *
+     * @param userId   the user id
+     * @param pageable the pageable
+     * @return the page
+     */
+    Page<Notification> findByUserIdAndReadFalseOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    /**
+     * Count by user id and read false long.
+     *
+     * @param userId the user id
+     * @return the long
+     */
+    long countByUserIdAndReadFalse(Long userId);
+
+    /**
+     * Mark all as read.
+     *
+     * @param userId the user id
+     * @param now    the now
+     */
+    @Modifying
+    @Query("update Notification n set n.read = true, n.readAt = :now where n.userId = :userId and n.read = false")
+    void markAllAsRead(@Param("userId") Long userId, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/shiftsync/shiftsync/notification/service/NotificationService.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/service/NotificationService.java
@@ -1,8 +1,19 @@
 package com.shiftsync.shiftsync.notification.service;
 
 import com.shiftsync.shiftsync.common.enums.NotificationType;
+import com.shiftsync.shiftsync.notification.dto.NotificationResponse;
+import com.shiftsync.shiftsync.notification.dto.UnreadCountResponse;
+import org.springframework.data.domain.Page;
 
 public interface NotificationService {
 
     void notifyUser(Long userId, NotificationType type, String message, String entityType, Long entityId);
+
+    Page<NotificationResponse> getInbox(Long actorUserId, boolean unreadOnly, int page, int size);
+
+    void markAsRead(Long actorUserId, Long notificationId);
+
+    void markAllAsRead(Long actorUserId);
+
+    UnreadCountResponse getUnreadCount(Long actorUserId);
 }

--- a/src/main/java/com/shiftsync/shiftsync/notification/service/NotificationService.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/service/NotificationService.java
@@ -9,7 +9,7 @@ public interface NotificationService {
 
     void notifyUser(Long userId, NotificationType type, String message, String entityType, Long entityId);
 
-    Page<NotificationResponse> getInbox(Long actorUserId, boolean unreadOnly, int page, int size);
+    Page<NotificationResponse> getInbox(Long actorUserId, Boolean read, int page, int size);
 
     void markAsRead(Long actorUserId, Long notificationId);
 

--- a/src/main/java/com/shiftsync/shiftsync/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/service/impl/NotificationServiceImpl.java
@@ -1,12 +1,21 @@
 package com.shiftsync.shiftsync.notification.service.impl;
 
 import com.shiftsync.shiftsync.common.enums.NotificationType;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.notification.dto.NotificationResponse;
+import com.shiftsync.shiftsync.notification.dto.UnreadCountResponse;
 import com.shiftsync.shiftsync.notification.entity.Notification;
 import com.shiftsync.shiftsync.notification.repository.NotificationRepository;
 import com.shiftsync.shiftsync.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +24,7 @@ public class NotificationServiceImpl implements NotificationService {
     private final NotificationRepository notificationRepository;
 
     @Override
+    @Async("notificationExecutor")
     @Transactional
     public void notifyUser(Long userId, NotificationType type, String message, String entityType, Long entityId) {
         Notification notification = Notification.builder()
@@ -25,5 +35,56 @@ public class NotificationServiceImpl implements NotificationService {
                 .entityId(entityId)
                 .build();
         notificationRepository.save(notification);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<NotificationResponse> getInbox(Long actorUserId, boolean unreadOnly, int page, int size) {
+        PageRequest pageable = PageRequest.of(page, size);
+        Page<Notification> results = unreadOnly
+                ? notificationRepository.findByUserIdAndReadFalseOrderByCreatedAtDesc(actorUserId, pageable)
+                : notificationRepository.findByUserIdOrderByCreatedAtDesc(actorUserId, pageable);
+        return results.map(this::toResponse);
+    }
+
+    @Override
+    @Transactional
+    public void markAsRead(Long actorUserId, Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Notification not found"));
+
+        if (!notification.getUserId().equals(actorUserId)) {
+            throw new BadRequestException("Notification does not belong to the current user");
+        }
+
+        if (!notification.isRead()) {
+            notification.setRead(true);
+            notification.setReadAt(LocalDateTime.now());
+        }
+    }
+
+    @Override
+    @Transactional
+    public void markAllAsRead(Long actorUserId) {
+        notificationRepository.markAllAsRead(actorUserId, LocalDateTime.now());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UnreadCountResponse getUnreadCount(Long actorUserId) {
+        return new UnreadCountResponse(notificationRepository.countByUserIdAndReadFalse(actorUserId));
+    }
+
+    private NotificationResponse toResponse(Notification n) {
+        return new NotificationResponse(
+                n.getId(),
+                n.getType(),
+                n.getMessage(),
+                n.getEntityType(),
+                n.getEntityId(),
+                n.isRead(),
+                n.getReadAt(),
+                n.getCreatedAt()
+        );
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/service/impl/NotificationServiceImpl.java
@@ -1,19 +1,23 @@
 package com.shiftsync.shiftsync.notification.service.impl;
 
 import com.shiftsync.shiftsync.common.enums.NotificationType;
-import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.notification.dto.NotificationResponse;
 import com.shiftsync.shiftsync.notification.dto.UnreadCountResponse;
 import com.shiftsync.shiftsync.notification.entity.Notification;
+import com.shiftsync.shiftsync.notification.entity.NotificationEvent;
 import com.shiftsync.shiftsync.notification.repository.NotificationRepository;
 import com.shiftsync.shiftsync.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.LocalDateTime;
 
@@ -22,26 +26,32 @@ import java.time.LocalDateTime;
 public class NotificationServiceImpl implements NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
+    public void notifyUser(Long userId, NotificationType type, String message, String entityType, Long entityId) {
+        eventPublisher.publishEvent(new NotificationEvent(userId, type, message, entityType, entityId));
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async("notificationExecutor")
     @Transactional
-    public void notifyUser(Long userId, NotificationType type, String message, String entityType, Long entityId) {
+    public void onNotificationEvent(NotificationEvent event) {
         Notification notification = Notification.builder()
-                .userId(userId)
-                .type(type)
-                .message(message)
-                .entityType(entityType)
-                .entityId(entityId)
+                .userId(event.userId())
+                .type(event.type())
+                .message(event.message())
+                .entityType(event.entityType())
+                .entityId(event.entityId())
                 .build();
         notificationRepository.save(notification);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public Page<NotificationResponse> getInbox(Long actorUserId, boolean unreadOnly, int page, int size) {
+    public Page<NotificationResponse> getInbox(Long actorUserId, Boolean read, int page, int size) {
         PageRequest pageable = PageRequest.of(page, size);
-        Page<Notification> results = unreadOnly
+        Page<Notification> results = Boolean.FALSE.equals(read)
                 ? notificationRepository.findByUserIdAndReadFalseOrderByCreatedAtDesc(actorUserId, pageable)
                 : notificationRepository.findByUserIdOrderByCreatedAtDesc(actorUserId, pageable);
         return results.map(this::toResponse);
@@ -54,7 +64,7 @@ public class NotificationServiceImpl implements NotificationService {
                 .orElseThrow(() -> new ResourceNotFoundException("Notification not found"));
 
         if (!notification.getUserId().equals(actorUserId)) {
-            throw new BadRequestException("Notification does not belong to the current user");
+            throw new AccessDeniedException("Notification does not belong to the current user");
         }
 
         if (!notification.isRead()) {

--- a/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftController.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/controller/ShiftController.java
@@ -4,6 +4,7 @@ import com.shiftsync.shiftsync.common.response.ErrorResponse;
 import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
 import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
+import com.shiftsync.shiftsync.shift.dto.UpdateShiftRequest;
 import com.shiftsync.shiftsync.shift.service.ShiftService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -58,6 +59,29 @@ public class ShiftController {
                         .buildAndExpand(response.id())
                         .toUri())
                 .body(response);
+    }
+
+    @PatchMapping("/{shiftId}")
+    @PreAuthorize("hasAnyRole('MANAGER', 'HR_ADMIN')")
+    @Operation(
+            summary = "Update a shift",
+            description = "Partially updates an open shift. All fields are optional — only provided fields are applied. Notifies all assigned employees asynchronously. Cannot update a cancelled shift."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Shift updated", content = @Content(schema = @Schema(implementation = ShiftResponse.class))),
+            @ApiResponse(responseCode = "400", description = "End time not after start time", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Manager not assigned to the location", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Shift not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "Shift is cancelled", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<ShiftResponse> updateShift(
+            Authentication authentication,
+            @PathVariable Long shiftId,
+            @Valid @RequestBody UpdateShiftRequest request
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        return ResponseEntity.ok(shiftService.updateShift(actorUserId, shiftId, request));
     }
 
     @PatchMapping("/{shiftId}/cancel")

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/UpdateShiftRequest.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/UpdateShiftRequest.java
@@ -1,0 +1,15 @@
+package com.shiftsync.shiftsync.shift.dto;
+
+import jakarta.validation.constraints.Min;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record UpdateShiftRequest(
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String requiredSkill,
+        @Min(value = 1, message = "minimumHeadcount must be at least 1")
+        Integer minimumHeadcount
+) {}

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
@@ -4,6 +4,7 @@ import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
 import com.shiftsync.shiftsync.shift.dto.EmployeeShiftResponse;
 import com.shiftsync.shiftsync.shift.dto.LocationShiftPageResponse;
 import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
+import com.shiftsync.shiftsync.shift.dto.UpdateShiftRequest;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -18,6 +19,16 @@ public interface ShiftService {
      * @return the created shift response
      */
     ShiftResponse createShift(Long actorUserId, CreateShiftRequest request);
+
+    /**
+     * Updates mutable fields on an existing open shift and notifies all assigned employees.
+     *
+     * @param actorUserId the ID of the authenticated user performing the update
+     * @param shiftId     the shift to update
+     * @param request     partial update — only non-null fields are applied
+     * @return the updated shift response
+     */
+    ShiftResponse updateShift(Long actorUserId, Long shiftId, UpdateShiftRequest request);
 
     /**
      * Cancels a shift and notifies all assigned employees.

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/impl/ShiftServiceImpl.java
@@ -22,6 +22,7 @@ import com.shiftsync.shiftsync.shift.dto.EmployeeShiftResponse;
 import com.shiftsync.shiftsync.shift.dto.LocationShiftPageResponse;
 import com.shiftsync.shiftsync.shift.dto.LocationShiftResponse;
 import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
+import com.shiftsync.shiftsync.shift.dto.UpdateShiftRequest;
 import com.shiftsync.shiftsync.shift.entity.Shift;
 import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
 import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
@@ -100,6 +101,60 @@ public class ShiftServiceImpl implements ShiftService {
         Shift saved = shiftRepository.save(shift);
 
         return toResponse(saved);
+    }
+
+    @Override
+    @Transactional
+    @CacheEvict(value = CacheConfig.LOCATION_SHIFTS, allEntries = true)
+    public ShiftResponse updateShift(Long actorUserId, Long shiftId, UpdateShiftRequest request) {
+        User actor = userRepository.findById(actorUserId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        Shift shift = shiftRepository.findById(shiftId)
+                .orElseThrow(() -> new ResourceNotFoundException("Shift not found"));
+
+        if (shift.getStatus() == ShiftStatus.CANCELLED) {
+            throw new InvalidStateException("Cannot update a cancelled shift");
+        }
+
+        if (actor.getRole() == UserRole.MANAGER) {
+            Employee managerEmployee = employeeRepository.findByUserId(actorUserId)
+                    .orElseThrow(() -> new ResourceNotFoundException("Manager profile not found"));
+            List<Long> assignedLocations = managerLocationRepository.findLocationIdsByManagerEmployeeId(managerEmployee.getId());
+            if (!assignedLocations.contains(shift.getLocation().getId())) {
+                throw new AccessDeniedException("You are not assigned to this location");
+            }
+        }
+
+        if (request.date() != null) shift.setShiftDate(request.date());
+        if (request.startTime() != null) shift.setStartTime(request.startTime());
+        if (request.endTime() != null) shift.setEndTime(request.endTime());
+        if (request.requiredSkill() != null) shift.setRequiredSkill(request.requiredSkill());
+        if (request.minimumHeadcount() != null) shift.setMinimumHeadcount(request.minimumHeadcount());
+
+        if (!shift.getEndTime().isAfter(shift.getStartTime())) {
+            throw new BadRequestException("End time must be after start time");
+        }
+
+        shiftRepository.save(shift);
+
+        List<ShiftAssignment> assignments = shiftAssignmentRepository.findByShiftId(shiftId);
+        String message = String.format(
+                "The shift on %s from %s to %s at %s has been updated.",
+                shift.getShiftDate(), shift.getStartTime(), shift.getEndTime(),
+                shift.getLocation().getName()
+        );
+        for (ShiftAssignment assignment : assignments) {
+            notificationService.notifyUser(
+                    assignment.getEmployee().getUser().getId(),
+                    NotificationType.SHIFT_CHANGED,
+                    message,
+                    "SHIFT",
+                    shift.getId()
+            );
+        }
+
+        return toResponse(shift);
     }
 
     @Override

--- a/src/test/java/com/shiftsync/shiftsync/notification/controller/NotificationControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/notification/controller/NotificationControllerWebMvcTest.java
@@ -1,0 +1,149 @@
+package com.shiftsync.shiftsync.notification.controller;
+
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import com.shiftsync.shiftsync.notification.dto.NotificationResponse;
+import com.shiftsync.shiftsync.notification.dto.UnreadCountResponse;
+import com.shiftsync.shiftsync.notification.service.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationController.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, AuthenticationHelper.class})
+class NotificationControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @Test
+    void getInbox_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/notifications"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1")
+    void getInbox_Authenticated_ReturnsOk() throws Exception {
+        when(notificationService.getInbox(anyLong(), anyBoolean(), anyInt(), anyInt()))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/v1/notifications"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "1")
+    void getInbox_UnreadOnly_ReturnsOk() throws Exception {
+        NotificationResponse response = new NotificationResponse(
+                1L, com.shiftsync.shiftsync.common.enums.NotificationType.SHIFT_ASSIGNED,
+                "You have been assigned a shift", "SHIFT", 10L,
+                false, null, LocalDateTime.now()
+        );
+        when(notificationService.getInbox(anyLong(), eq(true), anyInt(), anyInt()))
+                .thenReturn(new PageImpl<>(List.of(response)));
+
+        mockMvc.perform(get("/api/v1/notifications").param("unreadOnly", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(1));
+    }
+
+    @Test
+    void getUnreadCount_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/notifications/unread-count"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1")
+    void getUnreadCount_Authenticated_ReturnsCount() throws Exception {
+        when(notificationService.getUnreadCount(anyLong()))
+                .thenReturn(new UnreadCountResponse(5L));
+
+        mockMvc.perform(get("/api/v1/notifications/unread-count"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.count").value(5));
+    }
+
+    @Test
+    void markAsRead_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(patch("/api/v1/notifications/5/read"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1")
+    void markAsRead_ValidRequest_ReturnsNoContent() throws Exception {
+        mockMvc.perform(patch("/api/v1/notifications/5/read"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(username = "1")
+    void markAsRead_NotFound_ReturnsNotFound() throws Exception {
+        doThrow(new ResourceNotFoundException("Notification not found"))
+                .when(notificationService).markAsRead(anyLong(), eq(99L));
+
+        mockMvc.perform(patch("/api/v1/notifications/99/read"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "1")
+    void markAsRead_NotOwner_ReturnsBadRequest() throws Exception {
+        doThrow(new BadRequestException("Notification does not belong to the current user"))
+                .when(notificationService).markAsRead(anyLong(), eq(5L));
+
+        mockMvc.perform(patch("/api/v1/notifications/5/read"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Notification does not belong to the current user"));
+    }
+
+    @Test
+    void markAllAsRead_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(patch("/api/v1/notifications/read-all"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1")
+    void markAllAsRead_Authenticated_ReturnsNoContent() throws Exception {
+        mockMvc.perform(patch("/api/v1/notifications/read-all"))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/com/shiftsync/shiftsync/notification/controller/NotificationControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/notification/controller/NotificationControllerWebMvcTest.java
@@ -1,6 +1,5 @@
 package com.shiftsync.shiftsync.notification.controller;
 
-import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
@@ -15,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -23,10 +23,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -60,7 +60,7 @@ class NotificationControllerWebMvcTest {
     @Test
     @WithMockUser(username = "1")
     void getInbox_Authenticated_ReturnsOk() throws Exception {
-        when(notificationService.getInbox(anyLong(), anyBoolean(), anyInt(), anyInt()))
+        when(notificationService.getInbox(anyLong(), isNull(), anyInt(), anyInt()))
                 .thenReturn(new PageImpl<>(List.of()));
 
         mockMvc.perform(get("/api/v1/notifications"))
@@ -69,16 +69,16 @@ class NotificationControllerWebMvcTest {
 
     @Test
     @WithMockUser(username = "1")
-    void getInbox_UnreadOnly_ReturnsOk() throws Exception {
+    void getInbox_ReadFalse_ReturnsUnreadOnly() throws Exception {
         NotificationResponse response = new NotificationResponse(
                 1L, com.shiftsync.shiftsync.common.enums.NotificationType.SHIFT_ASSIGNED,
                 "You have been assigned a shift", "SHIFT", 10L,
                 false, null, LocalDateTime.now()
         );
-        when(notificationService.getInbox(anyLong(), eq(true), anyInt(), anyInt()))
+        when(notificationService.getInbox(anyLong(), eq(Boolean.FALSE), anyInt(), anyInt()))
                 .thenReturn(new PageImpl<>(List.of(response)));
 
-        mockMvc.perform(get("/api/v1/notifications").param("unreadOnly", "true"))
+        mockMvc.perform(get("/api/v1/notifications").param("read", "false"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].id").value(1));
     }
@@ -125,13 +125,12 @@ class NotificationControllerWebMvcTest {
 
     @Test
     @WithMockUser(username = "1")
-    void markAsRead_NotOwner_ReturnsBadRequest() throws Exception {
-        doThrow(new BadRequestException("Notification does not belong to the current user"))
+    void markAsRead_NotOwner_ReturnsForbidden() throws Exception {
+        doThrow(new AccessDeniedException("Notification does not belong to the current user"))
                 .when(notificationService).markAsRead(anyLong(), eq(5L));
 
         mockMvc.perform(patch("/api/v1/notifications/5/read"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("Notification does not belong to the current user"));
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/src/test/java/com/shiftsync/shiftsync/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/notification/service/NotificationServiceImplTest.java
@@ -1,0 +1,151 @@
+package com.shiftsync.shiftsync.notification.service;
+
+import com.shiftsync.shiftsync.common.enums.NotificationType;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
+import com.shiftsync.shiftsync.notification.dto.NotificationResponse;
+import com.shiftsync.shiftsync.notification.dto.UnreadCountResponse;
+import com.shiftsync.shiftsync.notification.entity.Notification;
+import com.shiftsync.shiftsync.notification.repository.NotificationRepository;
+import com.shiftsync.shiftsync.notification.service.impl.NotificationServiceImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceImplTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationServiceImpl notificationService;
+
+    @Test
+    void notifyUser_SavesNotificationWithCorrectFields() {
+        notificationService.notifyUser(1L, NotificationType.SHIFT_ASSIGNED, "You have been assigned", "SHIFT", 10L);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        Notification saved = captor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(1L);
+        assertThat(saved.getType()).isEqualTo(NotificationType.SHIFT_ASSIGNED);
+        assertThat(saved.getMessage()).isEqualTo("You have been assigned");
+        assertThat(saved.getEntityType()).isEqualTo("SHIFT");
+        assertThat(saved.getEntityId()).isEqualTo(10L);
+    }
+
+    @Test
+    void getInbox_UnreadOnlyFalse_ReturnsAllNotifications() {
+        Notification n = buildNotification(1L, 100L, false);
+        when(notificationRepository.findByUserIdOrderByCreatedAtDesc(eq(100L), any()))
+                .thenReturn(new PageImpl<>(List.of(n)));
+
+        Page<NotificationResponse> result = notificationService.getInbox(100L, false, 0, 20);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().getFirst().id()).isEqualTo(1L);
+        assertThat(result.getContent().getFirst().read()).isFalse();
+    }
+
+    @Test
+    void getInbox_UnreadOnlyTrue_QueriesUnreadRepository() {
+        Notification n = buildNotification(2L, 100L, false);
+        when(notificationRepository.findByUserIdAndReadFalseOrderByCreatedAtDesc(eq(100L), any()))
+                .thenReturn(new PageImpl<>(List.of(n)));
+
+        Page<NotificationResponse> result = notificationService.getInbox(100L, true, 0, 20);
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().getFirst().id()).isEqualTo(2L);
+    }
+
+    @Test
+    void markAsRead_UnreadNotification_SetsReadAndReadAt() {
+        Notification n = buildNotification(5L, 100L, false);
+        when(notificationRepository.findById(5L)).thenReturn(Optional.of(n));
+
+        notificationService.markAsRead(100L, 5L);
+
+        assertThat(n.isRead()).isTrue();
+        assertThat(n.getReadAt()).isNotNull();
+    }
+
+    @Test
+    void markAsRead_AlreadyRead_DoesNotUpdateReadAt() {
+        LocalDateTime existingReadAt = LocalDateTime.of(2026, 1, 1, 12, 0);
+        Notification n = buildNotification(5L, 100L, true);
+        n.setReadAt(existingReadAt);
+        when(notificationRepository.findById(5L)).thenReturn(Optional.of(n));
+
+        notificationService.markAsRead(100L, 5L);
+
+        assertThat(n.getReadAt()).isEqualTo(existingReadAt);
+    }
+
+    @Test
+    void markAsRead_NotFound_ThrowsResourceNotFound() {
+        when(notificationRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> notificationService.markAsRead(100L, 99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Notification not found");
+    }
+
+    @Test
+    void markAsRead_NotOwner_ThrowsBadRequest() {
+        Notification n = buildNotification(5L, 200L, false);
+        when(notificationRepository.findById(5L)).thenReturn(Optional.of(n));
+
+        assertThatThrownBy(() -> notificationService.markAsRead(100L, 5L))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Notification does not belong to the current user");
+    }
+
+    @Test
+    void markAllAsRead_CallsRepositoryWithCorrectUserId() {
+        notificationService.markAllAsRead(100L);
+
+        verify(notificationRepository).markAllAsRead(eq(100L), any(LocalDateTime.class));
+    }
+
+    @Test
+    void getUnreadCount_ReturnsCountFromRepository() {
+        when(notificationRepository.countByUserIdAndReadFalse(100L)).thenReturn(3L);
+
+        UnreadCountResponse result = notificationService.getUnreadCount(100L);
+
+        assertThat(result.count()).isEqualTo(3L);
+    }
+
+    private Notification buildNotification(Long id, Long userId, boolean read) {
+        Notification n = Notification.builder()
+                .id(id)
+                .userId(userId)
+                .type(NotificationType.SHIFT_ASSIGNED)
+                .message("Test notification")
+                .entityType("SHIFT")
+                .entityId(10L)
+                .build();
+        n.setRead(read);
+        n.setReadAt(read ? LocalDateTime.now() : null);
+        n.setCreatedAt(LocalDateTime.now());
+        return n;
+    }
+}

--- a/src/test/java/com/shiftsync/shiftsync/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/notification/service/NotificationServiceImplTest.java
@@ -1,11 +1,11 @@
 package com.shiftsync.shiftsync.notification.service;
 
 import com.shiftsync.shiftsync.common.enums.NotificationType;
-import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.common.exception.ResourceNotFoundException;
 import com.shiftsync.shiftsync.notification.dto.NotificationResponse;
 import com.shiftsync.shiftsync.notification.dto.UnreadCountResponse;
 import com.shiftsync.shiftsync.notification.entity.Notification;
+import com.shiftsync.shiftsync.notification.entity.NotificationEvent;
 import com.shiftsync.shiftsync.notification.repository.NotificationRepository;
 import com.shiftsync.shiftsync.notification.service.impl.NotificationServiceImpl;
 import org.junit.jupiter.api.Test;
@@ -14,8 +14,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -34,12 +36,31 @@ class NotificationServiceImplTest {
     @Mock
     private NotificationRepository notificationRepository;
 
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     @InjectMocks
     private NotificationServiceImpl notificationService;
 
     @Test
-    void notifyUser_SavesNotificationWithCorrectFields() {
+    void notifyUser_PublishesNotificationEvent() {
         notificationService.notifyUser(1L, NotificationType.SHIFT_ASSIGNED, "You have been assigned", "SHIFT", 10L);
+
+        ArgumentCaptor<NotificationEvent> captor = ArgumentCaptor.forClass(NotificationEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        NotificationEvent event = captor.getValue();
+        assertThat(event.userId()).isEqualTo(1L);
+        assertThat(event.type()).isEqualTo(NotificationType.SHIFT_ASSIGNED);
+        assertThat(event.message()).isEqualTo("You have been assigned");
+        assertThat(event.entityType()).isEqualTo("SHIFT");
+        assertThat(event.entityId()).isEqualTo(10L);
+    }
+
+    @Test
+    void onNotificationEvent_SavesNotificationWithCorrectFields() {
+        NotificationEvent event = new NotificationEvent(1L, NotificationType.SHIFT_ASSIGNED, "You have been assigned", "SHIFT", 10L);
+
+        notificationService.onNotificationEvent(event);
 
         ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         verify(notificationRepository).save(captor.capture());
@@ -52,12 +73,12 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void getInbox_UnreadOnlyFalse_ReturnsAllNotifications() {
+    void getInbox_ReadNull_ReturnsAllNotifications() {
         Notification n = buildNotification(1L, 100L, false);
         when(notificationRepository.findByUserIdOrderByCreatedAtDesc(eq(100L), any()))
                 .thenReturn(new PageImpl<>(List.of(n)));
 
-        Page<NotificationResponse> result = notificationService.getInbox(100L, false, 0, 20);
+        Page<NotificationResponse> result = notificationService.getInbox(100L, null, 0, 20);
 
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().getFirst().id()).isEqualTo(1L);
@@ -65,12 +86,12 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void getInbox_UnreadOnlyTrue_QueriesUnreadRepository() {
+    void getInbox_ReadFalse_QueriesUnreadRepository() {
         Notification n = buildNotification(2L, 100L, false);
         when(notificationRepository.findByUserIdAndReadFalseOrderByCreatedAtDesc(eq(100L), any()))
                 .thenReturn(new PageImpl<>(List.of(n)));
 
-        Page<NotificationResponse> result = notificationService.getInbox(100L, true, 0, 20);
+        Page<NotificationResponse> result = notificationService.getInbox(100L, Boolean.FALSE, 0, 20);
 
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().getFirst().id()).isEqualTo(2L);
@@ -109,12 +130,12 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void markAsRead_NotOwner_ThrowsBadRequest() {
+    void markAsRead_NotOwner_ThrowsForbidden() {
         Notification n = buildNotification(5L, 200L, false);
         when(notificationRepository.findById(5L)).thenReturn(Optional.of(n));
 
         assertThatThrownBy(() -> notificationService.markAsRead(100L, 5L))
-                .isInstanceOf(BadRequestException.class)
+                .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Notification does not belong to the current user");
     }
 

--- a/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/controller/ShiftControllerWebMvcTest.java
@@ -156,6 +156,74 @@ class ShiftControllerWebMvcTest {
                 .andExpect(status().isForbidden());
     }
 
+    private static final String UPDATE_BODY = """
+            {
+              "startTime": "08:00:00",
+              "endTime": "16:00:00"
+            }
+            """;
+
+    @Test
+    void updateShift_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(patch("/api/v1/shifts/50")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(UPDATE_BODY))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "EMPLOYEE")
+    void updateShift_WrongRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(patch("/api/v1/shifts/50")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(UPDATE_BODY))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void updateShift_ValidRequest_ReturnsOk() throws Exception {
+        ShiftResponse response = new ShiftResponse(
+                50L, 10L, "HQ", 20L, "Engineering",
+                LocalDate.of(2026, 6, 1),
+                LocalTime.of(8, 0), LocalTime.of(16, 0),
+                null, 2, "OPEN", 0
+        );
+        when(shiftService.updateShift(anyLong(), eq(50L), any())).thenReturn(response);
+
+        mockMvc.perform(patch("/api/v1/shifts/50")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(UPDATE_BODY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(50))
+                .andExpect(jsonPath("$.startTime").value("08:00:00"));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void updateShift_CancelledShift_ReturnsConflict() throws Exception {
+        doThrow(new InvalidStateException("Cannot update a cancelled shift"))
+                .when(shiftService).updateShift(anyLong(), eq(50L), any());
+
+        mockMvc.perform(patch("/api/v1/shifts/50")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(UPDATE_BODY))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("Cannot update a cancelled shift"));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void updateShift_NotFound_ReturnsNotFound() throws Exception {
+        doThrow(new ResourceNotFoundException("Shift not found"))
+                .when(shiftService).updateShift(anyLong(), eq(99L), any());
+
+        mockMvc.perform(patch("/api/v1/shifts/99")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(UPDATE_BODY))
+                .andExpect(status().isNotFound());
+    }
+
     @Test
     @WithMockUser(username = "1", roles = "MANAGER")
     void getLocationShifts_ValidRequest_ReturnsOk() throws Exception {

--- a/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/shift/service/ShiftServiceImplTest.java
@@ -19,6 +19,7 @@ import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
 import com.shiftsync.shiftsync.shift.dto.EmployeeShiftResponse;
 import com.shiftsync.shiftsync.shift.dto.LocationShiftPageResponse;
 import com.shiftsync.shiftsync.shift.dto.ShiftResponse;
+import com.shiftsync.shiftsync.shift.dto.UpdateShiftRequest;
 import com.shiftsync.shiftsync.shift.entity.Shift;
 import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
 import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
@@ -329,5 +330,83 @@ class ShiftServiceImplTest {
 
         assertThat(response.totalElements()).isEqualTo(1);
         assertThat(response.content().getFirst().shiftId()).isEqualTo(50L);
+    }
+
+    @Test
+    void updateShift_ValidRequest_UpdatesFieldsAndNotifiesAssignees() {
+        ShiftAssignment assignment = ShiftAssignment.builder()
+                .id(1L).shift(shift).employee(employee).assignedBy(managerUser)
+                .overrideApplied(false).build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(shiftRepository.findById(50L)).thenReturn(Optional.of(shift));
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(manager));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(100L)).thenReturn(List.of(10L));
+        when(shiftAssignmentRepository.findByShiftId(50L)).thenReturn(List.of(assignment));
+        when(shiftRepository.save(any(Shift.class))).thenReturn(shift);
+
+        UpdateShiftRequest request = new UpdateShiftRequest(
+                null, LocalTime.of(8, 0), LocalTime.of(16, 0), null, null
+        );
+
+        ShiftResponse response = shiftService.updateShift(1L, 50L, request);
+
+        assertThat(shift.getStartTime()).isEqualTo(LocalTime.of(8, 0));
+        assertThat(shift.getEndTime()).isEqualTo(LocalTime.of(16, 0));
+        assertThat(response).isNotNull();
+        verify(notificationService).notifyUser(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void updateShift_CancelledShift_ThrowsInvalidState() {
+        shift.setStatus(ShiftStatus.CANCELLED);
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(shiftRepository.findById(50L)).thenReturn(Optional.of(shift));
+
+        UpdateShiftRequest request = new UpdateShiftRequest(null, null, null, null, null);
+
+        assertThatThrownBy(() -> shiftService.updateShift(1L, 50L, request))
+                .isInstanceOf(InvalidStateException.class)
+                .hasMessage("Cannot update a cancelled shift");
+    }
+
+    @Test
+    void updateShift_TimeOrderViolation_ThrowsBadRequest() {
+        when(userRepository.findById(2L)).thenReturn(Optional.of(hrAdminUser));
+        when(shiftRepository.findById(50L)).thenReturn(Optional.of(shift));
+
+        UpdateShiftRequest request = new UpdateShiftRequest(
+                null, LocalTime.of(17, 0), LocalTime.of(9, 0), null, null
+        );
+
+        assertThatThrownBy(() -> shiftService.updateShift(2L, 50L, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("End time must be after start time");
+    }
+
+    @Test
+    void updateShift_ManagerNotAtLocation_ThrowsAccessDenied() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(shiftRepository.findById(50L)).thenReturn(Optional.of(shift));
+        when(employeeRepository.findByUserId(1L)).thenReturn(Optional.of(manager));
+        when(managerLocationRepository.findLocationIdsByManagerEmployeeId(100L)).thenReturn(List.of(99L));
+
+        UpdateShiftRequest request = new UpdateShiftRequest(null, null, null, "Java", null);
+
+        assertThatThrownBy(() -> shiftService.updateShift(1L, 50L, request))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void updateShift_ShiftNotFound_ThrowsNotFound() {
+        when(userRepository.findById(1L)).thenReturn(Optional.of(managerUser));
+        when(shiftRepository.findById(99L)).thenReturn(Optional.empty());
+
+        UpdateShiftRequest request = new UpdateShiftRequest(null, null, null, null, null);
+
+        assertThatThrownBy(() -> shiftService.updateShift(1L, 99L, request))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Shift not found");
     }
 }


### PR DESCRIPTION
## What
Implements Epic 7: async notification delivery and the notification inbox API (FR-NOTIF-01 through FR-NOTIF-04), plus the missing shift update flow that triggers `SHIFT_CHANGED` notifications (FR-NOTIF-01).

Changes:
- `AsyncConfig` — registers a `ThreadPoolTaskExecutor` named `notificationExecutor` with `@EnableAsync`
- `NotificationServiceImpl.notifyUser` — annotated `@Async("notificationExecutor")` so the HTTP response no longer waits for notification persistence
- `NotificationRepository` — paginated inbox queries, unread-only filter, unread count, bulk mark-all-read via JPQL `@Modifying`
- `NotificationController` — four endpoints: `GET /api/v1/notifications`, `GET /unread-count`, `PATCH /{id}/read`, `PATCH /read-all`
- `ShiftController` / `ShiftService` / `ShiftServiceImpl` — `PATCH /api/v1/shifts/{id}` for partial shift updates; fires `SHIFT_CHANGED` to all assigned employees on change

## Why
FR-NOTIF-01: Employees must receive in-system notifications for shift assignment, removal, cancellation, shift change, leave status update, and swap outcome.
FR-NOTIF-02: Notifications must be delivered asynchronously — the triggering HTTP response must not block on delivery.
FR-NOTIF-03: Employees need a paginated inbox to retrieve and manage their notifications.
FR-NOTIF-04: A lightweight unread-count endpoint is needed for frontend polling.
The `SHIFT_CHANGED` type was defined in the enum but had no triggering flow; the shift update endpoint closes that gap.

## How to test
1. Log in as MANAGER, create a shift via `POST /api/v1/shifts`
2. Assign an employee via `POST /api/v1/shifts/{id}/assignments`
3. Update the shift via `PATCH /api/v1/shifts/{id}` with a new `startTime` — expect `200` and the updated shift in the response
4. Log in as the assigned employee, call `GET /api/v1/notifications` — expect a `SHIFT_CHANGED` notification in the inbox
5. Call `GET /api/v1/notifications/unread-count` — expect `count: 1`
6. Call `PATCH /api/v1/notifications/{id}/read` — expect `204`; re-check the count, expect `count: 0`
7. Trigger a second notification (e.g. cancel the shift), then call `PATCH /api/v1/notifications/read-all` — expect `204` and count back to `0`
8. Attempt `PATCH /api/v1/shifts/{id}` on a cancelled shift — expect `409`
9. Attempt any notification endpoint without a token — expect `401`

## Notes
`notifyUser` is called from within `@Transactional` methods in other services. Making it `@Async` means it runs in its own thread with its own transaction — notifications are committed independently after the parent transaction commits. This is intentional: a notification failure must never roll back a shift assignment or swap approval.
`PATCH /api/v1/shifts/{id}` is a partial update — only non-null fields in the request body are applied. Sending `{}` is a no-op.
