### PR TITLE
feat: reporting endpoints for coverage, overtime, and leave utilization

### DIFF
--- a/src/main/java/com/shiftsync/shiftsync/employee/dto/EmployeePageResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/employee/dto/EmployeePageResponse.java
@@ -6,7 +6,7 @@ public record EmployeePageResponse(
         List<EmployeeResponse> content,
         long totalElements,
         int totalPages,
-        int currentPage
+        int page
 ) {
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/leave/dto/PendingLeaveRequestPageResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/dto/PendingLeaveRequestPageResponse.java
@@ -6,7 +6,7 @@ public record PendingLeaveRequestPageResponse(
         List<PendingLeaveRequestResponse> content,
         long totalElements,
         int totalPages,
-        int currentPage
+        int page
 ) {
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/leave/repository/LeaveRequestRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/repository/LeaveRequestRepository.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * The interface Leave request repository.
@@ -39,6 +40,25 @@ public interface LeaveRequestRepository extends JpaRepository<LeaveRequest, Long
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate,
             @Param("statuses") Collection<LeaveStatus> statuses
+    );
+
+    @Query("""
+            select lr
+            from LeaveRequest lr
+            join fetch lr.employee e
+            join fetch e.user u
+            join fetch e.department d
+            where lr.status = :status
+              and lr.startDate <= :to
+              and lr.endDate >= :from
+              and (:locationId is null or e.location.id = :locationId)
+            order by e.id asc
+            """)
+    List<LeaveRequest> findByStatusInRangeByOptionalLocation(
+            @Param("from") LocalDate from,
+            @Param("to") LocalDate to,
+            @Param("status") LeaveStatus status,
+            @Param("locationId") Long locationId
     );
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/report/controller/ReportController.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/controller/ReportController.java
@@ -4,6 +4,8 @@ import com.shiftsync.shiftsync.common.response.ErrorResponse;
 import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
 import com.shiftsync.shiftsync.report.dto.CoverageReportPageResponse;
+import com.shiftsync.shiftsync.report.dto.OvertimeReportEntry;
+import com.shiftsync.shiftsync.report.dto.OvertimeReportPageResponse;
 import com.shiftsync.shiftsync.report.exporter.CsvExporter;
 import com.shiftsync.shiftsync.report.service.ReportService;
 import com.shiftsync.shiftsync.shift.service.ShiftService;
@@ -91,5 +93,54 @@ public class ReportController {
                 .header("Content-Disposition", "attachment; filename=\"coverage-report.csv\"")
                 .contentType(MediaType.parseMediaType("text/csv"))
                 .body(csvExporter.toCoverageCsv(entries));
+    }
+
+    @GetMapping(value = "/overtime", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(
+            summary = "Overtime report (JSON)",
+            description = "Returns a paginated list of employees who exceeded contracted hours in the period, sorted by overage descending. locationId is optional."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Overtime report returned",
+                    content = @Content(schema = @Schema(implementation = OvertimeReportPageResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<OvertimeReportPageResponse> getOvertimeReport(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) Long locationId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(reportService.getOvertimeReport(locationId, from, to, page, size));
+    }
+
+    @GetMapping(value = "/overtime", produces = "text/csv")
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(
+            summary = "Overtime report (CSV)",
+            description = "Returns the full overtime report for a pay period as a downloadable CSV file."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Overtime CSV returned"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<String> getOvertimeReportCsv(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) Long locationId
+    ) {
+        List<OvertimeReportEntry> entries = reportService.getAllOvertimeEntries(locationId, from, to);
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=\"overtime-report.csv\"")
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(csvExporter.toOvertimeCsv(entries));
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/report/controller/ReportController.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/controller/ReportController.java
@@ -4,6 +4,7 @@ import com.shiftsync.shiftsync.common.response.ErrorResponse;
 import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
 import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
 import com.shiftsync.shiftsync.report.dto.CoverageReportPageResponse;
+import com.shiftsync.shiftsync.report.dto.LeaveUtilizationReportResponse;
 import com.shiftsync.shiftsync.report.dto.OvertimeReportEntry;
 import com.shiftsync.shiftsync.report.dto.OvertimeReportPageResponse;
 import com.shiftsync.shiftsync.report.exporter.CsvExporter;
@@ -142,5 +143,54 @@ public class ReportController {
                 .header("Content-Disposition", "attachment; filename=\"overtime-report.csv\"")
                 .contentType(MediaType.parseMediaType("text/csv"))
                 .body(csvExporter.toOvertimeCsv(entries));
+    }
+
+    @GetMapping(value = "/leave", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(
+            summary = "Leave utilization report (JSON)",
+            description = "Returns a paginated per-employee leave breakdown with department-level aggregates. locationId is optional."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Leave utilization report returned",
+                    content = @Content(schema = @Schema(implementation = LeaveUtilizationReportResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<LeaveUtilizationReportResponse> getLeaveReport(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) Long locationId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(reportService.getLeaveReport(locationId, from, to, page, size));
+    }
+
+    @GetMapping(value = "/leave", produces = "text/csv")
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(
+            summary = "Leave utilization report (CSV)",
+            description = "Returns the full leave utilization report with department aggregates as a downloadable CSV file."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Leave utilization CSV returned"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Forbidden",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<String> getLeaveReportCsv(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) Long locationId
+    ) {
+        LeaveUtilizationReportResponse data = reportService.getAllLeaveData(locationId, from, to);
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=\"leave-utilization-report.csv\"")
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(csvExporter.toLeaveCsv(data.employees(), data.departmentAggregates()));
     }
 }

--- a/src/main/java/com/shiftsync/shiftsync/report/controller/ReportController.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/controller/ReportController.java
@@ -1,0 +1,95 @@
+package com.shiftsync.shiftsync.report.controller;
+
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
+import com.shiftsync.shiftsync.report.dto.CoverageReportPageResponse;
+import com.shiftsync.shiftsync.report.exporter.CsvExporter;
+import com.shiftsync.shiftsync.report.service.ReportService;
+import com.shiftsync.shiftsync.shift.service.ShiftService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/reports")
+@RequiredArgsConstructor
+@Tag(name = "Reports", description = "Reporting endpoints for coverage, overtime, and leave utilization")
+public class ReportController {
+
+    private final ReportService reportService;
+    private final ShiftService shiftService;
+    private final AuthenticationHelper authenticationHelper;
+    private final CsvExporter csvExporter;
+
+    @GetMapping(value = "/coverage", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PreAuthorize("hasAnyRole('MANAGER', 'HR_ADMIN')")
+    @Operation(
+            summary = "Coverage report (JSON)",
+            description = "Returns paginated shift coverage for a location and date range. Managers are restricted to their assigned locations."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Coverage report returned",
+                    content = @Content(schema = @Schema(implementation = CoverageReportPageResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Manager not assigned to this location",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<CoverageReportPageResponse> getCoverageReport(
+            Authentication authentication,
+            @RequestParam Long locationId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        shiftService.verifyManagerLocationAccess(actorUserId, locationId);
+        return ResponseEntity.ok(reportService.getCoverageReport(locationId, from, to, page, size));
+    }
+
+    @GetMapping(value = "/coverage", produces = "text/csv")
+    @PreAuthorize("hasAnyRole('MANAGER', 'HR_ADMIN')")
+    @Operation(
+            summary = "Coverage report (CSV)",
+            description = "Returns full shift coverage for a location and date range as a downloadable CSV file."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Coverage CSV returned"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Manager not assigned to this location",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<String> getCoverageReportCsv(
+            Authentication authentication,
+            @RequestParam Long locationId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to
+    ) {
+        Long actorUserId = authenticationHelper.getCurrentUserId(authentication);
+        shiftService.verifyManagerLocationAccess(actorUserId, locationId);
+        List<CoverageReportEntry> entries = reportService.getAllCoverageEntries(locationId, from, to);
+        return ResponseEntity.ok()
+                .header("Content-Disposition", "attachment; filename=\"coverage-report.csv\"")
+                .contentType(MediaType.parseMediaType("text/csv"))
+                .body(csvExporter.toCoverageCsv(entries));
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/report/dto/CoverageReportEntry.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/dto/CoverageReportEntry.java
@@ -1,0 +1,20 @@
+package com.shiftsync.shiftsync.report.dto;
+
+import com.shiftsync.shiftsync.shift.entity.StaffingStatus;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record CoverageReportEntry(
+        Long shiftId,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String departmentName,
+        Integer requiredHeadcount,
+        Integer assignedCount,
+        StaffingStatus staffingStatus,
+        List<String> employeeNames
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/report/dto/CoverageReportPageResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/dto/CoverageReportPageResponse.java
@@ -6,6 +6,6 @@ public record CoverageReportPageResponse(
         List<CoverageReportEntry> content,
         int totalElements,
         int totalPages,
-        int currentPage
+        int page
 ) {
 }

--- a/src/main/java/com/shiftsync/shiftsync/report/dto/CoverageReportPageResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/dto/CoverageReportPageResponse.java
@@ -1,0 +1,11 @@
+package com.shiftsync.shiftsync.report.dto;
+
+import java.util.List;
+
+public record CoverageReportPageResponse(
+        List<CoverageReportEntry> content,
+        int totalElements,
+        int totalPages,
+        int currentPage
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/report/dto/DepartmentLeaveAggregate.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/dto/DepartmentLeaveAggregate.java
@@ -1,0 +1,10 @@
+package com.shiftsync.shiftsync.report.dto;
+
+public record DepartmentLeaveAggregate(
+        String departmentName,
+        long annualDaysTaken,
+        long sickDaysTaken,
+        long unpaidDaysTaken,
+        long totalDaysTaken
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/report/dto/LeaveEmployeeEntry.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/dto/LeaveEmployeeEntry.java
@@ -1,0 +1,12 @@
+package com.shiftsync.shiftsync.report.dto;
+
+public record LeaveEmployeeEntry(
+        Long employeeId,
+        String employeeName,
+        String departmentName,
+        long annualDaysTaken,
+        long sickDaysTaken,
+        long unpaidDaysTaken,
+        long totalDaysTaken
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/report/dto/LeaveUtilizationReportResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/dto/LeaveUtilizationReportResponse.java
@@ -1,0 +1,12 @@
+package com.shiftsync.shiftsync.report.dto;
+
+import java.util.List;
+
+public record LeaveUtilizationReportResponse(
+        List<LeaveEmployeeEntry> employees,
+        int totalElements,
+        int totalPages,
+        int currentPage,
+        List<DepartmentLeaveAggregate> departmentAggregates
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/report/dto/LeaveUtilizationReportResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/dto/LeaveUtilizationReportResponse.java
@@ -6,7 +6,7 @@ public record LeaveUtilizationReportResponse(
         List<LeaveEmployeeEntry> employees,
         int totalElements,
         int totalPages,
-        int currentPage,
+        int page,
         List<DepartmentLeaveAggregate> departmentAggregates
 ) {
 }

--- a/src/main/java/com/shiftsync/shiftsync/report/dto/OvertimeReportEntry.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/dto/OvertimeReportEntry.java
@@ -1,0 +1,14 @@
+package com.shiftsync.shiftsync.report.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record OvertimeReportEntry(
+        Long employeeId,
+        String employeeName,
+        BigDecimal contractedWeeklyHours,
+        BigDecimal actualHoursInPeriod,
+        BigDecimal overtimeHours,
+        List<OvertimeShiftEntry> contributingShifts
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/report/dto/OvertimeReportPageResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/dto/OvertimeReportPageResponse.java
@@ -6,6 +6,6 @@ public record OvertimeReportPageResponse(
         List<OvertimeReportEntry> content,
         int totalElements,
         int totalPages,
-        int currentPage
+        int page
 ) {
 }

--- a/src/main/java/com/shiftsync/shiftsync/report/dto/OvertimeReportPageResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/dto/OvertimeReportPageResponse.java
@@ -1,0 +1,11 @@
+package com.shiftsync.shiftsync.report.dto;
+
+import java.util.List;
+
+public record OvertimeReportPageResponse(
+        List<OvertimeReportEntry> content,
+        int totalElements,
+        int totalPages,
+        int currentPage
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/report/dto/OvertimeShiftEntry.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/dto/OvertimeShiftEntry.java
@@ -1,0 +1,16 @@
+package com.shiftsync.shiftsync.report.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record OvertimeShiftEntry(
+        Long shiftId,
+        LocalDate date,
+        LocalTime startTime,
+        LocalTime endTime,
+        String locationName,
+        String departmentName,
+        BigDecimal hoursWorked
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/report/exporter/CsvExporter.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/exporter/CsvExporter.java
@@ -1,9 +1,11 @@
 package com.shiftsync.shiftsync.report.exporter;
 
 import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
+import com.shiftsync.shiftsync.report.dto.OvertimeReportEntry;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class CsvExporter {
@@ -21,6 +23,23 @@ public class CsvExporter {
                     .append(entry.assignedCount()).append(",")
                     .append(entry.staffingStatus()).append(",")
                     .append(escapeCsv(String.join("; ", entry.employeeNames()))).append("\n");
+        }
+        return sb.toString();
+    }
+
+    public String toOvertimeCsv(List<OvertimeReportEntry> entries) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Employee ID,Employee Name,Contracted Weekly Hours,Actual Hours In Period,Overtime Hours,Contributing Shifts\n");
+        for (OvertimeReportEntry entry : entries) {
+            String shiftSummary = entry.contributingShifts().stream()
+                    .map(s -> s.date() + " " + s.startTime() + "-" + s.endTime() + " @ " + s.locationName())
+                    .collect(Collectors.joining(" | "));
+            sb.append(entry.employeeId()).append(",")
+                    .append(escapeCsv(entry.employeeName())).append(",")
+                    .append(entry.contractedWeeklyHours()).append(",")
+                    .append(entry.actualHoursInPeriod()).append(",")
+                    .append(entry.overtimeHours()).append(",")
+                    .append(escapeCsv(shiftSummary)).append("\n");
         }
         return sb.toString();
     }

--- a/src/main/java/com/shiftsync/shiftsync/report/exporter/CsvExporter.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/exporter/CsvExporter.java
@@ -1,6 +1,8 @@
 package com.shiftsync.shiftsync.report.exporter;
 
 import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
+import com.shiftsync.shiftsync.report.dto.DepartmentLeaveAggregate;
+import com.shiftsync.shiftsync.report.dto.LeaveEmployeeEntry;
 import com.shiftsync.shiftsync.report.dto.OvertimeReportEntry;
 import org.springframework.stereotype.Component;
 
@@ -40,6 +42,30 @@ public class CsvExporter {
                     .append(entry.actualHoursInPeriod()).append(",")
                     .append(entry.overtimeHours()).append(",")
                     .append(escapeCsv(shiftSummary)).append("\n");
+        }
+        return sb.toString();
+    }
+
+    public String toLeaveCsv(List<LeaveEmployeeEntry> employees, List<DepartmentLeaveAggregate> aggregates) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Employee ID,Employee Name,Department,Annual Days,Sick Days,Unpaid Days,Total Days\n");
+        for (LeaveEmployeeEntry entry : employees) {
+            sb.append(entry.employeeId()).append(",")
+                    .append(escapeCsv(entry.employeeName())).append(",")
+                    .append(escapeCsv(entry.departmentName())).append(",")
+                    .append(entry.annualDaysTaken()).append(",")
+                    .append(entry.sickDaysTaken()).append(",")
+                    .append(entry.unpaidDaysTaken()).append(",")
+                    .append(entry.totalDaysTaken()).append("\n");
+        }
+        sb.append("\nDepartment Aggregates\n");
+        sb.append("Department,Annual Days,Sick Days,Unpaid Days,Total Days\n");
+        for (DepartmentLeaveAggregate agg : aggregates) {
+            sb.append(escapeCsv(agg.departmentName())).append(",")
+                    .append(agg.annualDaysTaken()).append(",")
+                    .append(agg.sickDaysTaken()).append(",")
+                    .append(agg.unpaidDaysTaken()).append(",")
+                    .append(agg.totalDaysTaken()).append("\n");
         }
         return sb.toString();
     }

--- a/src/main/java/com/shiftsync/shiftsync/report/exporter/CsvExporter.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/exporter/CsvExporter.java
@@ -1,0 +1,35 @@
+package com.shiftsync.shiftsync.report.exporter;
+
+import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CsvExporter {
+
+    public String toCoverageCsv(List<CoverageReportEntry> entries) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Shift ID,Date,Start Time,End Time,Department,Required Headcount,Assigned Count,Staffing Status,Employee Names\n");
+        for (CoverageReportEntry entry : entries) {
+            sb.append(entry.shiftId()).append(",")
+                    .append(entry.date()).append(",")
+                    .append(entry.startTime()).append(",")
+                    .append(entry.endTime()).append(",")
+                    .append(escapeCsv(entry.departmentName())).append(",")
+                    .append(entry.requiredHeadcount()).append(",")
+                    .append(entry.assignedCount()).append(",")
+                    .append(entry.staffingStatus()).append(",")
+                    .append(escapeCsv(String.join("; ", entry.employeeNames()))).append("\n");
+        }
+        return sb.toString();
+    }
+
+    private String escapeCsv(String value) {
+        if (value == null) return "";
+        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/report/service/ReportService.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/service/ReportService.java
@@ -2,6 +2,8 @@ package com.shiftsync.shiftsync.report.service;
 
 import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
 import com.shiftsync.shiftsync.report.dto.CoverageReportPageResponse;
+import com.shiftsync.shiftsync.report.dto.OvertimeReportEntry;
+import com.shiftsync.shiftsync.report.dto.OvertimeReportPageResponse;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,4 +19,14 @@ public interface ReportService {
      * Returns all coverage entries for a location and date range (used for CSV export).
      */
     List<CoverageReportEntry> getAllCoverageEntries(Long locationId, LocalDate from, LocalDate to);
+
+    /**
+     * Returns a paginated overtime report for a pay period, optionally filtered by location.
+     */
+    OvertimeReportPageResponse getOvertimeReport(Long locationId, LocalDate from, LocalDate to, int page, int size);
+
+    /**
+     * Returns all overtime entries for a pay period (used for CSV export).
+     */
+    List<OvertimeReportEntry> getAllOvertimeEntries(Long locationId, LocalDate from, LocalDate to);
 }

--- a/src/main/java/com/shiftsync/shiftsync/report/service/ReportService.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/service/ReportService.java
@@ -1,0 +1,20 @@
+package com.shiftsync.shiftsync.report.service;
+
+import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
+import com.shiftsync.shiftsync.report.dto.CoverageReportPageResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ReportService {
+
+    /**
+     * Returns a paginated coverage report for a location and date range.
+     */
+    CoverageReportPageResponse getCoverageReport(Long locationId, LocalDate from, LocalDate to, int page, int size);
+
+    /**
+     * Returns all coverage entries for a location and date range (used for CSV export).
+     */
+    List<CoverageReportEntry> getAllCoverageEntries(Long locationId, LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/shiftsync/shiftsync/report/service/ReportService.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/service/ReportService.java
@@ -2,6 +2,7 @@ package com.shiftsync.shiftsync.report.service;
 
 import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
 import com.shiftsync.shiftsync.report.dto.CoverageReportPageResponse;
+import com.shiftsync.shiftsync.report.dto.LeaveUtilizationReportResponse;
 import com.shiftsync.shiftsync.report.dto.OvertimeReportEntry;
 import com.shiftsync.shiftsync.report.dto.OvertimeReportPageResponse;
 
@@ -29,4 +30,14 @@ public interface ReportService {
      * Returns all overtime entries for a pay period (used for CSV export).
      */
     List<OvertimeReportEntry> getAllOvertimeEntries(Long locationId, LocalDate from, LocalDate to);
+
+    /**
+     * Returns a paginated leave utilization report with department-level aggregates.
+     */
+    LeaveUtilizationReportResponse getLeaveReport(Long locationId, LocalDate from, LocalDate to, int page, int size);
+
+    /**
+     * Returns all leave data unpaginated (used for CSV export).
+     */
+    LeaveUtilizationReportResponse getAllLeaveData(Long locationId, LocalDate from, LocalDate to);
 }

--- a/src/main/java/com/shiftsync/shiftsync/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/service/impl/ReportServiceImpl.java
@@ -21,6 +21,9 @@ import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
 import com.shiftsync.shiftsync.shift.repository.ShiftRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,14 +50,41 @@ public class ReportServiceImpl implements ReportService {
     @Override
     @Transactional(readOnly = true)
     public CoverageReportPageResponse getCoverageReport(Long locationId, LocalDate from, LocalDate to, int page, int size) {
-        List<CoverageReportEntry> all = fetchCoverageEntries(locationId, from, to);
-        int totalElements = all.size();
-        int totalPages = size > 0 ? (int) Math.ceil((double) totalElements / size) : 0;
-        int start = page * size;
-        List<CoverageReportEntry> content = start >= totalElements
-                ? List.of()
-                : all.subList(start, Math.min(start + size, totalElements));
-        return new CoverageReportPageResponse(content, totalElements, totalPages, page);
+        if (from.isAfter(to)) {
+            throw new BadRequestException("'from' date must not be after 'to' date");
+        }
+        PageRequest pageable = PageRequest.of(page, size, Sort.by("shiftDate", "startTime"));
+        Page<Shift> shiftPage = shiftRepository.findActiveByLocationInRange(locationId, from, to, pageable);
+
+        Set<Long> shiftIds = shiftPage.getContent().stream().map(Shift::getId).collect(Collectors.toSet());
+        Map<Long, List<ShiftAssignment>> assignmentsByShift = shiftIds.isEmpty()
+                ? Map.of()
+                : shiftAssignmentRepository.findAssignmentsByShiftIds(shiftIds)
+                        .stream()
+                        .collect(Collectors.groupingBy(a -> a.getShift().getId()));
+
+        List<CoverageReportEntry> content = shiftPage.getContent().stream()
+                .map(shift -> {
+                    List<ShiftAssignment> assignments = assignmentsByShift.getOrDefault(shift.getId(), List.of());
+                    int assignedCount = assignments.size();
+                    List<String> employeeNames = assignments.stream()
+                            .map(a -> a.getEmployee().getUser().getFullName())
+                            .toList();
+                    return new CoverageReportEntry(
+                            shift.getId(),
+                            shift.getShiftDate(),
+                            shift.getStartTime(),
+                            shift.getEndTime(),
+                            shift.getDepartment().getName(),
+                            shift.getMinimumHeadcount(),
+                            assignedCount,
+                            resolveStaffingStatus(assignedCount, shift.getMinimumHeadcount()),
+                            employeeNames
+                    );
+                })
+                .toList();
+
+        return new CoverageReportPageResponse(content, (int) shiftPage.getTotalElements(), shiftPage.getTotalPages(), page);
     }
 
     @Override
@@ -128,8 +158,12 @@ public class ReportServiceImpl implements ReportService {
         if (from.isAfter(to)) {
             throw new BadRequestException("'from' date must not be after 'to' date");
         }
+        // Grouping by employee to compute per-employee hour totals cannot be pushed into SQL without
+        // a complex window-function query. The in-memory approach is acceptable here because the
+        // result set is bounded by the date range and location filter. Performance depends on the
+        // composite index on (shift_assignment.shift_date, shift_assignment.employee_id).
         List<ShiftAssignment> assignments = shiftAssignmentRepository
-                .findAllInDateRangeByOptionalLocation(from, to, ShiftStatus.CANCELLED, locationId);
+                .findAllInDateRangeByOptionalLocation(from, to, locationId);
 
         long daysInPeriod = ChronoUnit.DAYS.between(from, to) + 1;
 

--- a/src/main/java/com/shiftsync/shiftsync/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/service/impl/ReportServiceImpl.java
@@ -2,6 +2,9 @@ package com.shiftsync.shiftsync.report.service.impl;
 
 import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
 import com.shiftsync.shiftsync.report.dto.CoverageReportPageResponse;
+import com.shiftsync.shiftsync.report.dto.OvertimeReportEntry;
+import com.shiftsync.shiftsync.report.dto.OvertimeReportPageResponse;
+import com.shiftsync.shiftsync.report.dto.OvertimeShiftEntry;
 import com.shiftsync.shiftsync.report.service.ReportService;
 import com.shiftsync.shiftsync.shift.entity.Shift;
 import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
@@ -13,9 +16,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,7 +38,7 @@ public class ReportServiceImpl implements ReportService {
     @Override
     @Transactional(readOnly = true)
     public CoverageReportPageResponse getCoverageReport(Long locationId, LocalDate from, LocalDate to, int page, int size) {
-        List<CoverageReportEntry> all = getAllCoverageEntries(locationId, from, to);
+        List<CoverageReportEntry> all = fetchCoverageEntries(locationId, from, to);
         int totalElements = all.size();
         int totalPages = size > 0 ? (int) Math.ceil((double) totalElements / size) : 0;
         int start = page * size;
@@ -42,6 +51,29 @@ public class ReportServiceImpl implements ReportService {
     @Override
     @Transactional(readOnly = true)
     public List<CoverageReportEntry> getAllCoverageEntries(Long locationId, LocalDate from, LocalDate to) {
+        return fetchCoverageEntries(locationId, from, to);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public OvertimeReportPageResponse getOvertimeReport(Long locationId, LocalDate from, LocalDate to, int page, int size) {
+        List<OvertimeReportEntry> all = fetchOvertimeEntries(locationId, from, to);
+        int totalElements = all.size();
+        int totalPages = size > 0 ? (int) Math.ceil((double) totalElements / size) : 0;
+        int start = page * size;
+        List<OvertimeReportEntry> content = start >= totalElements
+                ? List.of()
+                : all.subList(start, Math.min(start + size, totalElements));
+        return new OvertimeReportPageResponse(content, totalElements, totalPages, page);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OvertimeReportEntry> getAllOvertimeEntries(Long locationId, LocalDate from, LocalDate to) {
+        return fetchOvertimeEntries(locationId, from, to);
+    }
+
+    private List<CoverageReportEntry> fetchCoverageEntries(Long locationId, LocalDate from, LocalDate to) {
         List<Shift> shifts = shiftRepository.findByLocationInRange(locationId, from, to)
                 .stream()
                 .filter(s -> s.getStatus() != ShiftStatus.CANCELLED)
@@ -64,7 +96,7 @@ public class ReportServiceImpl implements ReportService {
                     int assignedCount = assignments.size();
                     List<String> employeeNames = assignments.stream()
                             .map(a -> a.getEmployee().getUser().getFullName())
-                            .collect(Collectors.toList());
+                            .toList();
                     return new CoverageReportEntry(
                             shift.getId(),
                             shift.getShiftDate(),
@@ -77,7 +109,73 @@ public class ReportServiceImpl implements ReportService {
                             employeeNames
                     );
                 })
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    private List<OvertimeReportEntry> fetchOvertimeEntries(Long locationId, LocalDate from, LocalDate to) {
+        List<ShiftAssignment> assignments = shiftAssignmentRepository
+                .findAllInDateRangeByOptionalLocation(from, to, ShiftStatus.CANCELLED, locationId);
+
+        long daysInPeriod = ChronoUnit.DAYS.between(from, to) + 1;
+
+        return assignments.stream()
+                .collect(Collectors.groupingBy(a -> a.getEmployee().getId()))
+                .values()
+                .stream()
+                .map(employeeAssignments -> {
+                    ShiftAssignment first = employeeAssignments.getFirst();
+                    BigDecimal contractedWeeklyHours = first.getEmployee().getContractedWeeklyHours();
+
+                    BigDecimal expectedHours = contractedWeeklyHours
+                            .multiply(BigDecimal.valueOf(daysInPeriod))
+                            .divide(BigDecimal.valueOf(7), 2, RoundingMode.HALF_UP);
+
+                    BigDecimal actualHours = employeeAssignments.stream()
+                            .map(a -> {
+                                long minutes = Duration.between(
+                                        a.getShift().getStartTime(), a.getShift().getEndTime()
+                                ).toMinutes();
+                                return BigDecimal.valueOf(minutes)
+                                        .divide(BigDecimal.valueOf(60), 2, RoundingMode.HALF_UP);
+                            })
+                            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+                    BigDecimal overage = actualHours.subtract(expectedHours);
+                    if (overage.compareTo(BigDecimal.ZERO) <= 0) {
+                        return null;
+                    }
+
+                    List<OvertimeShiftEntry> contributingShifts = employeeAssignments.stream()
+                            .map(a -> {
+                                Shift shift = a.getShift();
+                                long minutes = Duration.between(shift.getStartTime(), shift.getEndTime()).toMinutes();
+                                BigDecimal hours = BigDecimal.valueOf(minutes)
+                                        .divide(BigDecimal.valueOf(60), 2, RoundingMode.HALF_UP);
+                                return new OvertimeShiftEntry(
+                                        shift.getId(),
+                                        shift.getShiftDate(),
+                                        shift.getStartTime(),
+                                        shift.getEndTime(),
+                                        shift.getLocation().getName(),
+                                        shift.getDepartment().getName(),
+                                        hours
+                                );
+                            })
+                            .sorted(Comparator.comparing(OvertimeShiftEntry::date))
+                            .toList();
+
+                    return new OvertimeReportEntry(
+                            first.getEmployee().getId(),
+                            first.getEmployee().getUser().getFullName(),
+                            contractedWeeklyHours,
+                            actualHours,
+                            overage,
+                            contributingShifts
+                    );
+                })
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(OvertimeReportEntry::overtimeHours).reversed())
+                .toList();
     }
 
     private StaffingStatus resolveStaffingStatus(int assignedCount, int minimumHeadcount) {

--- a/src/main/java/com/shiftsync/shiftsync/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/service/impl/ReportServiceImpl.java
@@ -17,6 +17,7 @@ import com.shiftsync.shiftsync.shift.entity.Shift;
 import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
 import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
 import com.shiftsync.shiftsync.shift.entity.StaffingStatus;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
 import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
 import com.shiftsync.shiftsync.shift.repository.ShiftRepository;
 import lombok.RequiredArgsConstructor;
@@ -82,6 +83,9 @@ public class ReportServiceImpl implements ReportService {
     }
 
     private List<CoverageReportEntry> fetchCoverageEntries(Long locationId, LocalDate from, LocalDate to) {
+        if (from.isAfter(to)) {
+            throw new BadRequestException("'from' date must not be after 'to' date");
+        }
         List<Shift> shifts = shiftRepository.findByLocationInRange(locationId, from, to)
                 .stream()
                 .filter(s -> s.getStatus() != ShiftStatus.CANCELLED)
@@ -121,6 +125,9 @@ public class ReportServiceImpl implements ReportService {
     }
 
     private List<OvertimeReportEntry> fetchOvertimeEntries(Long locationId, LocalDate from, LocalDate to) {
+        if (from.isAfter(to)) {
+            throw new BadRequestException("'from' date must not be after 'to' date");
+        }
         List<ShiftAssignment> assignments = shiftAssignmentRepository
                 .findAllInDateRangeByOptionalLocation(from, to, ShiftStatus.CANCELLED, locationId);
 
@@ -207,6 +214,9 @@ public class ReportServiceImpl implements ReportService {
     }
 
     private LeaveUtilizationReportResponse fetchLeaveData(Long locationId, LocalDate from, LocalDate to) {
+        if (from.isAfter(to)) {
+            throw new BadRequestException("'from' date must not be after 'to' date");
+        }
         List<LeaveRequest> leaveRequests = leaveRequestRepository
                 .findByStatusInRangeByOptionalLocation(from, to, LeaveStatus.APPROVED, locationId);
 

--- a/src/main/java/com/shiftsync/shiftsync/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/service/impl/ReportServiceImpl.java
@@ -1,7 +1,14 @@
 package com.shiftsync.shiftsync.report.service.impl;
 
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.enums.LeaveType;
+import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
+import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
 import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
 import com.shiftsync.shiftsync.report.dto.CoverageReportPageResponse;
+import com.shiftsync.shiftsync.report.dto.DepartmentLeaveAggregate;
+import com.shiftsync.shiftsync.report.dto.LeaveEmployeeEntry;
+import com.shiftsync.shiftsync.report.dto.LeaveUtilizationReportResponse;
 import com.shiftsync.shiftsync.report.dto.OvertimeReportEntry;
 import com.shiftsync.shiftsync.report.dto.OvertimeReportPageResponse;
 import com.shiftsync.shiftsync.report.dto.OvertimeShiftEntry;
@@ -34,6 +41,7 @@ public class ReportServiceImpl implements ReportService {
 
     private final ShiftRepository shiftRepository;
     private final ShiftAssignmentRepository shiftAssignmentRepository;
+    private final LeaveRequestRepository leaveRequestRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -176,6 +184,81 @@ public class ReportServiceImpl implements ReportService {
                 .filter(Objects::nonNull)
                 .sorted(Comparator.comparing(OvertimeReportEntry::overtimeHours).reversed())
                 .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public LeaveUtilizationReportResponse getLeaveReport(Long locationId, LocalDate from, LocalDate to, int page, int size) {
+        LeaveUtilizationReportResponse full = fetchLeaveData(locationId, from, to);
+        List<LeaveEmployeeEntry> all = full.employees();
+        int totalElements = all.size();
+        int totalPages = size > 0 ? (int) Math.ceil((double) totalElements / size) : 0;
+        int start = page * size;
+        List<LeaveEmployeeEntry> content = start >= totalElements
+                ? List.of()
+                : all.subList(start, Math.min(start + size, totalElements));
+        return new LeaveUtilizationReportResponse(content, totalElements, totalPages, page, full.departmentAggregates());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public LeaveUtilizationReportResponse getAllLeaveData(Long locationId, LocalDate from, LocalDate to) {
+        return fetchLeaveData(locationId, from, to);
+    }
+
+    private LeaveUtilizationReportResponse fetchLeaveData(Long locationId, LocalDate from, LocalDate to) {
+        List<LeaveRequest> leaveRequests = leaveRequestRepository
+                .findByStatusInRangeByOptionalLocation(from, to, LeaveStatus.APPROVED, locationId);
+
+        List<LeaveEmployeeEntry> employees = leaveRequests.stream()
+                .collect(Collectors.groupingBy(lr -> lr.getEmployee().getId()))
+                .values()
+                .stream()
+                .map(employeeLeaves -> {
+                    LeaveRequest first = employeeLeaves.getFirst();
+                    Map<LeaveType, Long> daysByType = employeeLeaves.stream()
+                            .collect(Collectors.toMap(
+                                    LeaveRequest::getLeaveType,
+                                    lr -> calculateDaysInPeriod(lr, from, to),
+                                    Long::sum
+                            ));
+                    long annual = daysByType.getOrDefault(LeaveType.ANNUAL, 0L);
+                    long sick = daysByType.getOrDefault(LeaveType.SICK, 0L);
+                    long unpaid = daysByType.getOrDefault(LeaveType.UNPAID, 0L);
+                    return new LeaveEmployeeEntry(
+                            first.getEmployee().getId(),
+                            first.getEmployee().getUser().getFullName(),
+                            first.getEmployee().getDepartment().getName(),
+                            annual,
+                            sick,
+                            unpaid,
+                            annual + sick + unpaid
+                    );
+                })
+                .sorted(Comparator.comparing(LeaveEmployeeEntry::employeeName))
+                .toList();
+
+        List<DepartmentLeaveAggregate> aggregates = employees.stream()
+                .collect(Collectors.groupingBy(LeaveEmployeeEntry::departmentName))
+                .entrySet()
+                .stream()
+                .map(e -> new DepartmentLeaveAggregate(
+                        e.getKey(),
+                        e.getValue().stream().mapToLong(LeaveEmployeeEntry::annualDaysTaken).sum(),
+                        e.getValue().stream().mapToLong(LeaveEmployeeEntry::sickDaysTaken).sum(),
+                        e.getValue().stream().mapToLong(LeaveEmployeeEntry::unpaidDaysTaken).sum(),
+                        e.getValue().stream().mapToLong(LeaveEmployeeEntry::totalDaysTaken).sum()
+                ))
+                .sorted(Comparator.comparing(DepartmentLeaveAggregate::departmentName))
+                .toList();
+
+        return new LeaveUtilizationReportResponse(employees, employees.size(), 1, 0, aggregates);
+    }
+
+    private long calculateDaysInPeriod(LeaveRequest lr, LocalDate from, LocalDate to) {
+        LocalDate effectiveStart = lr.getStartDate().isBefore(from) ? from : lr.getStartDate();
+        LocalDate effectiveEnd = lr.getEndDate().isAfter(to) ? to : lr.getEndDate();
+        return ChronoUnit.DAYS.between(effectiveStart, effectiveEnd) + 1;
     }
 
     private StaffingStatus resolveStaffingStatus(int assignedCount, int minimumHeadcount) {

--- a/src/main/java/com/shiftsync/shiftsync/report/service/impl/ReportServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/report/service/impl/ReportServiceImpl.java
@@ -1,0 +1,88 @@
+package com.shiftsync.shiftsync.report.service.impl;
+
+import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
+import com.shiftsync.shiftsync.report.dto.CoverageReportPageResponse;
+import com.shiftsync.shiftsync.report.service.ReportService;
+import com.shiftsync.shiftsync.shift.entity.Shift;
+import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
+import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
+import com.shiftsync.shiftsync.shift.entity.StaffingStatus;
+import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
+import com.shiftsync.shiftsync.shift.repository.ShiftRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReportServiceImpl implements ReportService {
+
+    private final ShiftRepository shiftRepository;
+    private final ShiftAssignmentRepository shiftAssignmentRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public CoverageReportPageResponse getCoverageReport(Long locationId, LocalDate from, LocalDate to, int page, int size) {
+        List<CoverageReportEntry> all = getAllCoverageEntries(locationId, from, to);
+        int totalElements = all.size();
+        int totalPages = size > 0 ? (int) Math.ceil((double) totalElements / size) : 0;
+        int start = page * size;
+        List<CoverageReportEntry> content = start >= totalElements
+                ? List.of()
+                : all.subList(start, Math.min(start + size, totalElements));
+        return new CoverageReportPageResponse(content, totalElements, totalPages, page);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CoverageReportEntry> getAllCoverageEntries(Long locationId, LocalDate from, LocalDate to) {
+        List<Shift> shifts = shiftRepository.findByLocationInRange(locationId, from, to)
+                .stream()
+                .filter(s -> s.getStatus() != ShiftStatus.CANCELLED)
+                .toList();
+
+        if (shifts.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> shiftIds = shifts.stream().map(Shift::getId).collect(Collectors.toSet());
+
+        Map<Long, List<ShiftAssignment>> assignmentsByShift = shiftAssignmentRepository
+                .findAssignmentsByShiftIds(shiftIds)
+                .stream()
+                .collect(Collectors.groupingBy(a -> a.getShift().getId()));
+
+        return shifts.stream()
+                .map(shift -> {
+                    List<ShiftAssignment> assignments = assignmentsByShift.getOrDefault(shift.getId(), List.of());
+                    int assignedCount = assignments.size();
+                    List<String> employeeNames = assignments.stream()
+                            .map(a -> a.getEmployee().getUser().getFullName())
+                            .collect(Collectors.toList());
+                    return new CoverageReportEntry(
+                            shift.getId(),
+                            shift.getShiftDate(),
+                            shift.getStartTime(),
+                            shift.getEndTime(),
+                            shift.getDepartment().getName(),
+                            shift.getMinimumHeadcount(),
+                            assignedCount,
+                            resolveStaffingStatus(assignedCount, shift.getMinimumHeadcount()),
+                            employeeNames
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+
+    private StaffingStatus resolveStaffingStatus(int assignedCount, int minimumHeadcount) {
+        if (assignedCount < minimumHeadcount) return StaffingStatus.UNDERSTAFFED;
+        if (assignedCount == minimumHeadcount) return StaffingStatus.FULLY_STAFFED;
+        return StaffingStatus.OVERSTAFFED;
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/shift/dto/LocationShiftPageResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/dto/LocationShiftPageResponse.java
@@ -6,6 +6,6 @@ public record LocationShiftPageResponse(
         List<LocationShiftResponse> content,
         int totalElements,
         int totalPages,
-        int currentPage
+        int page
 ) {
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
@@ -138,14 +138,13 @@ public interface ShiftAssignmentRepository extends JpaRepository<ShiftAssignment
             join fetch s.department
             where s.shiftDate >= :from
               and s.shiftDate <= :to
-              and s.status <> :cancelled
+              and s.status <> com.shiftsync.shiftsync.shift.entity.ShiftStatus.CANCELLED
               and (:locationId is null or e.location.id = :locationId)
             order by e.id asc
             """)
     List<ShiftAssignment> findAllInDateRangeByOptionalLocation(
             @Param("from") LocalDate from,
             @Param("to") LocalDate to,
-            @Param("cancelled") ShiftStatus cancelled,
             @Param("locationId") Long locationId
     );
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftAssignmentRepository.java
@@ -127,4 +127,25 @@ public interface ShiftAssignmentRepository extends JpaRepository<ShiftAssignment
             @Param("startTime") LocalTime startTime,
             @Param("endTime") LocalTime endTime
     );
+
+    @Query("""
+            select sa
+            from ShiftAssignment sa
+            join fetch sa.employee e
+            join fetch e.user u
+            join fetch sa.shift s
+            join fetch s.location
+            join fetch s.department
+            where s.shiftDate >= :from
+              and s.shiftDate <= :to
+              and s.status <> :cancelled
+              and (:locationId is null or e.location.id = :locationId)
+            order by e.id asc
+            """)
+    List<ShiftAssignment> findAllInDateRangeByOptionalLocation(
+            @Param("from") LocalDate from,
+            @Param("to") LocalDate to,
+            @Param("cancelled") ShiftStatus cancelled,
+            @Param("locationId") Long locationId
+    );
 }

--- a/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/repository/ShiftRepository.java
@@ -2,6 +2,8 @@ package com.shiftsync.shiftsync.shift.repository;
 
 import com.shiftsync.shiftsync.shift.entity.Shift;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -36,5 +38,30 @@ public interface ShiftRepository extends JpaRepository<Shift, Long> {
             @Param("locationId") Long locationId,
             @Param("from") LocalDate from,
             @Param("to") LocalDate to
+    );
+
+    @Query(value = """
+            select s
+            from Shift s
+            join fetch s.location
+            join fetch s.department
+            where s.location.id = :locationId
+              and s.shiftDate >= :from
+              and s.shiftDate <= :to
+              and s.status <> com.shiftsync.shiftsync.shift.entity.ShiftStatus.CANCELLED
+            """,
+            countQuery = """
+            select count(s)
+            from Shift s
+            where s.location.id = :locationId
+              and s.shiftDate >= :from
+              and s.shiftDate <= :to
+              and s.status <> com.shiftsync.shiftsync.shift.entity.ShiftStatus.CANCELLED
+            """)
+    Page<Shift> findActiveByLocationInRange(
+            @Param("locationId") Long locationId,
+            @Param("from") LocalDate from,
+            @Param("to") LocalDate to,
+            Pageable pageable
     );
 }

--- a/src/test/java/com/shiftsync/shiftsync/employee/controller/EmployeeControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/employee/controller/EmployeeControllerWebMvcTest.java
@@ -194,7 +194,7 @@ class EmployeeControllerWebMvcTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalElements").value(1))
                 .andExpect(jsonPath("$.totalPages").value(1))
-                .andExpect(jsonPath("$.currentPage").value(0))
+                .andExpect(jsonPath("$.page").value(0))
                 .andExpect(jsonPath("$.content[0].employeeId").value(10));
     }
 

--- a/src/test/java/com/shiftsync/shiftsync/employee/service/EmployeeServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/employee/service/EmployeeServiceImplTest.java
@@ -201,7 +201,7 @@ class EmployeeServiceImplTest {
 
         assertThat(result.totalElements()).isEqualTo(1);
         assertThat(result.totalPages()).isEqualTo(1);
-        assertThat(result.currentPage()).isEqualTo(0);
+        assertThat(result.page()).isEqualTo(0);
         assertThat(result.content()).hasSize(1);
     }
 

--- a/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/leave/service/LeaveRequestServiceImplTest.java
@@ -238,7 +238,7 @@ class LeaveRequestServiceImplTest {
 
         assertThat(result.totalElements()).isEqualTo(1);
         assertThat(result.totalPages()).isEqualTo(1);
-        assertThat(result.currentPage()).isEqualTo(0);
+        assertThat(result.page()).isEqualTo(0);
         assertThat(result.content()).hasSize(1);
         assertThat(result.content().getFirst().employeeName()).isEqualTo("Employee One");
     }

--- a/src/test/java/com/shiftsync/shiftsync/report/controller/ReportControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/report/controller/ReportControllerWebMvcTest.java
@@ -1,0 +1,205 @@
+package com.shiftsync.shiftsync.report.controller;
+
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.common.util.AuthenticationHelper;
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import com.shiftsync.shiftsync.report.dto.CoverageReportPageResponse;
+import com.shiftsync.shiftsync.report.dto.LeaveUtilizationReportResponse;
+import com.shiftsync.shiftsync.report.dto.OvertimeReportPageResponse;
+import com.shiftsync.shiftsync.report.exporter.CsvExporter;
+import com.shiftsync.shiftsync.report.service.ReportService;
+import com.shiftsync.shiftsync.shift.service.ShiftService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReportController.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class, AuthenticationHelper.class})
+class ReportControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ReportService reportService;
+
+    @MockitoBean
+    private ShiftService shiftService;
+
+    @MockitoBean
+    private CsvExporter csvExporter;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    // ── Coverage ───────────────────────────────────────────────────────────────
+
+    @Test
+    void getCoverageReport_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/reports/coverage")
+                        .param("locationId", "10")
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "EMPLOYEE")
+    void getCoverageReport_EmployeeRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/reports/coverage")
+                        .param("locationId", "10")
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void getCoverageReport_ManagerRole_ReturnsOk() throws Exception {
+        when(reportService.getCoverageReport(anyLong(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(new CoverageReportPageResponse(List.of(), 0, 0, 0));
+
+        mockMvc.perform(get("/api/v1/reports/coverage")
+                        .param("locationId", "10")
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void getCoverageReport_FromAfterTo_ReturnsBadRequest() throws Exception {
+        when(reportService.getCoverageReport(anyLong(), any(), any(), anyInt(), anyInt()))
+                .thenThrow(new BadRequestException("'from' date must not be after 'to' date"));
+
+        mockMvc.perform(get("/api/v1/reports/coverage")
+                        .param("locationId", "10")
+                        .param("from", "2026-06-30")
+                        .param("to", "2026-06-01"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("'from' date must not be after 'to' date"));
+    }
+
+    @Test
+    void getCoverageReportCsv_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/reports/coverage")
+                        .accept("text/csv")
+                        .param("locationId", "10")
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ── Overtime ───────────────────────────────────────────────────────────────
+
+    @Test
+    void getOvertimeReport_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/reports/overtime")
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void getOvertimeReport_ManagerRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/reports/overtime")
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void getOvertimeReport_HrAdminRole_ReturnsOk() throws Exception {
+        when(reportService.getOvertimeReport(any(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(new OvertimeReportPageResponse(List.of(), 0, 0, 0));
+
+        mockMvc.perform(get("/api/v1/reports/overtime")
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void getOvertimeReport_FromAfterTo_ReturnsBadRequest() throws Exception {
+        when(reportService.getOvertimeReport(any(), any(), any(), anyInt(), anyInt()))
+                .thenThrow(new BadRequestException("'from' date must not be after 'to' date"));
+
+        mockMvc.perform(get("/api/v1/reports/overtime")
+                        .param("from", "2026-06-30")
+                        .param("to", "2026-06-01"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("'from' date must not be after 'to' date"));
+    }
+
+    // ── Leave ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void getLeaveReport_WithoutToken_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/reports/leave")
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "MANAGER")
+    void getLeaveReport_ManagerRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/reports/leave")
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void getLeaveReport_HrAdminRole_ReturnsOk() throws Exception {
+        when(reportService.getLeaveReport(any(), any(), any(), anyInt(), anyInt()))
+                .thenReturn(new LeaveUtilizationReportResponse(List.of(), 0, 0, 0, List.of()));
+
+        mockMvc.perform(get("/api/v1/reports/leave")
+                        .param("from", "2026-06-01")
+                        .param("to", "2026-06-30"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "HR_ADMIN")
+    void getLeaveReport_FromAfterTo_ReturnsBadRequest() throws Exception {
+        when(reportService.getLeaveReport(any(), any(), any(), anyInt(), anyInt()))
+                .thenThrow(new BadRequestException("'from' date must not be after 'to' date"));
+
+        mockMvc.perform(get("/api/v1/reports/leave")
+                        .param("from", "2026-06-30")
+                        .param("to", "2026-06-01"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("'from' date must not be after 'to' date"));
+    }
+}

--- a/src/test/java/com/shiftsync/shiftsync/report/service/ReportServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/report/service/ReportServiceImplTest.java
@@ -32,6 +32,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -41,6 +45,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -76,7 +81,8 @@ class ReportServiceImplTest {
     void getCoverageReport_WithOpenShiftsAndAssignees_ReturnsCorrectEntry() {
         ShiftAssignment assignment = buildAssignment(1L, shift, employee);
 
-        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of(shift));
+        when(shiftRepository.findActiveByLocationInRange(eq(10L), eq(FROM), eq(TO), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(shift)));
         when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of(assignment));
 
         CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 20);
@@ -92,19 +98,9 @@ class ReportServiceImplTest {
     }
 
     @Test
-    void getCoverageReport_CancelledShift_ExcludedFromReport() {
-        shift.setStatus(ShiftStatus.CANCELLED);
-        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of(shift));
-
-        CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 20);
-
-        assertThat(response.totalElements()).isEqualTo(0);
-        assertThat(response.content()).isEmpty();
-    }
-
-    @Test
-    void getCoverageReport_NoShifts_ReturnsEmptyPage() {
-        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of());
+    void getCoverageReport_NoActiveShifts_ReturnsEmptyPage() {
+        when(shiftRepository.findActiveByLocationInRange(eq(10L), eq(FROM), eq(TO), any(Pageable.class)))
+                .thenReturn(Page.empty());
 
         CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 20);
 
@@ -114,20 +110,18 @@ class ReportServiceImplTest {
     }
 
     @Test
-    void getCoverageReport_PaginationSlicesCorrectly() {
+    void getCoverageReport_ReturnsPageMetadataFromRepository() {
         Shift s2 = buildShift(51L, LocalDate.of(2026, 6, 2), LocalTime.of(10, 0), LocalTime.of(18, 0), 1);
-        Shift s3 = buildShift(52L, LocalDate.of(2026, 6, 3), LocalTime.of(10, 0), LocalTime.of(18, 0), 1);
 
-        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of(shift, s2, s3));
+        when(shiftRepository.findActiveByLocationInRange(eq(10L), eq(FROM), eq(TO), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(shift, s2), PageRequest.of(0, 2), 5));
         when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of());
 
-        CoverageReportPageResponse page0 = reportService.getCoverageReport(10L, FROM, TO, 0, 2);
-        CoverageReportPageResponse page1 = reportService.getCoverageReport(10L, FROM, TO, 1, 2);
+        CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 2);
 
-        assertThat(page0.content()).hasSize(2);
-        assertThat(page0.totalElements()).isEqualTo(3);
-        assertThat(page0.totalPages()).isEqualTo(2);
-        assertThat(page1.content()).hasSize(1);
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.totalElements()).isEqualTo(5);
+        assertThat(response.totalPages()).isEqualTo(3);
     }
 
     @Test
@@ -136,7 +130,8 @@ class ReportServiceImplTest {
         ShiftAssignment a1 = buildAssignment(1L, shift, employee);
         ShiftAssignment a2 = buildAssignment(2L, shift, buildEmployee(200L, u2));
 
-        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of(shift));
+        when(shiftRepository.findActiveByLocationInRange(eq(10L), eq(FROM), eq(TO), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(shift)));
         when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of(a1, a2));
 
         CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 20);
@@ -152,7 +147,8 @@ class ReportServiceImplTest {
         ShiftAssignment a2 = buildAssignment(2L, shift, buildEmployee(200L, u2));
         ShiftAssignment a3 = buildAssignment(3L, shift, buildEmployee(300L, u3));
 
-        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of(shift));
+        when(shiftRepository.findActiveByLocationInRange(eq(10L), eq(FROM), eq(TO), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(shift)));
         when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of(a1, a2, a3));
 
         CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 20);
@@ -188,7 +184,7 @@ class ReportServiceImplTest {
         ShiftAssignment a1 = buildAssignment(1L, shift, employee);
         ShiftAssignment a2 = buildAssignment(2L, s2, employee);
 
-        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, ShiftStatus.CANCELLED, null))
+        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, null))
                 .thenReturn(List.of(a1, a2));
 
         OvertimeReportPageResponse response = reportService.getOvertimeReport(null, FROM, TO, 0, 20);
@@ -207,7 +203,7 @@ class ReportServiceImplTest {
         // contractedWeeklyHours=10, period=7 days → expected=10h; one 8h shift=8h < 10h
         ShiftAssignment a1 = buildAssignment(1L, shift, employee);
 
-        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, ShiftStatus.CANCELLED, null))
+        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, null))
                 .thenReturn(List.of(a1));
 
         OvertimeReportPageResponse response = reportService.getOvertimeReport(null, FROM, TO, 0, 20);
@@ -225,7 +221,7 @@ class ReportServiceImplTest {
         Shift s3 = buildShift(52L, LocalDate.of(2026, 6, 3), LocalTime.of(9, 0), LocalTime.of(17, 0), 1);
         Shift s4 = buildShift(53L, LocalDate.of(2026, 6, 4), LocalTime.of(9, 0), LocalTime.of(17, 0), 1);
 
-        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, ShiftStatus.CANCELLED, null))
+        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, null))
                 .thenReturn(List.of(
                         buildAssignment(1L, shift, employee),
                         buildAssignment(2L, s2, employee),
@@ -245,7 +241,7 @@ class ReportServiceImplTest {
 
     @Test
     void getOvertimeReport_NoAssignments_ReturnsEmptyPage() {
-        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, ShiftStatus.CANCELLED, null))
+        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, null))
                 .thenReturn(List.of());
 
         OvertimeReportPageResponse response = reportService.getOvertimeReport(null, FROM, TO, 0, 20);
@@ -259,7 +255,7 @@ class ReportServiceImplTest {
         Shift earlier = buildShift(51L, LocalDate.of(2026, 6, 3), LocalTime.of(9, 0), LocalTime.of(17, 0), 1);
         Shift later   = buildShift(52L, LocalDate.of(2026, 6, 5), LocalTime.of(9, 0), LocalTime.of(17, 0), 1);
 
-        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, ShiftStatus.CANCELLED, null))
+        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, null))
                 .thenReturn(List.of(
                         buildAssignment(1L, shift, employee),
                         buildAssignment(2L, later, employee),

--- a/src/test/java/com/shiftsync/shiftsync/report/service/ReportServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/report/service/ReportServiceImplTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -100,7 +99,7 @@ class ReportServiceImplTest {
     @Test
     void getCoverageReport_NoActiveShifts_ReturnsEmptyPage() {
         when(shiftRepository.findActiveByLocationInRange(eq(10L), eq(FROM), eq(TO), any(Pageable.class)))
-                .thenReturn(Page.empty());
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 20), 0));
 
         CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 20);
 

--- a/src/test/java/com/shiftsync/shiftsync/report/service/ReportServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/report/service/ReportServiceImplTest.java
@@ -1,0 +1,437 @@
+package com.shiftsync.shiftsync.report.service;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.common.enums.EmploymentType;
+import com.shiftsync.shiftsync.common.enums.LeaveStatus;
+import com.shiftsync.shiftsync.common.enums.LeaveType;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import com.shiftsync.shiftsync.common.exception.BadRequestException;
+import com.shiftsync.shiftsync.department.entity.Department;
+import com.shiftsync.shiftsync.employee.entity.Employee;
+import com.shiftsync.shiftsync.leave.entity.LeaveRequest;
+import com.shiftsync.shiftsync.leave.repository.LeaveRequestRepository;
+import com.shiftsync.shiftsync.location.entity.Location;
+import com.shiftsync.shiftsync.report.dto.CoverageReportEntry;
+import com.shiftsync.shiftsync.report.dto.CoverageReportPageResponse;
+import com.shiftsync.shiftsync.report.dto.DepartmentLeaveAggregate;
+import com.shiftsync.shiftsync.report.dto.LeaveEmployeeEntry;
+import com.shiftsync.shiftsync.report.dto.LeaveUtilizationReportResponse;
+import com.shiftsync.shiftsync.report.dto.OvertimeReportEntry;
+import com.shiftsync.shiftsync.report.dto.OvertimeReportPageResponse;
+import com.shiftsync.shiftsync.report.dto.OvertimeShiftEntry;
+import com.shiftsync.shiftsync.report.service.impl.ReportServiceImpl;
+import com.shiftsync.shiftsync.shift.entity.Shift;
+import com.shiftsync.shiftsync.shift.entity.ShiftAssignment;
+import com.shiftsync.shiftsync.shift.entity.ShiftStatus;
+import com.shiftsync.shiftsync.shift.entity.StaffingStatus;
+import com.shiftsync.shiftsync.shift.repository.ShiftAssignmentRepository;
+import com.shiftsync.shiftsync.shift.repository.ShiftRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceImplTest {
+
+    @Mock private ShiftRepository shiftRepository;
+    @Mock private ShiftAssignmentRepository shiftAssignmentRepository;
+    @Mock private LeaveRequestRepository leaveRequestRepository;
+
+    @InjectMocks private ReportServiceImpl reportService;
+
+    private static final LocalDate FROM = LocalDate.of(2026, 6, 1);
+    private static final LocalDate TO   = LocalDate.of(2026, 6, 7);
+
+    private User user;
+    private Employee employee;
+    private Location location;
+    private Department department;
+    private Shift shift;
+
+    @BeforeEach
+    void setUp() {
+        user       = User.builder().id(1L).fullName("Alice").role(UserRole.EMPLOYEE).build();
+        location   = Location.builder().id(10L).name("HQ").address("Accra").maxHeadcountPerShift(10).active(true).build();
+        department = Department.builder().id(20L).name("Kitchen").location(location).build();
+        employee   = buildEmployee(100L, user);
+        shift      = buildShift(50L, FROM, LocalTime.of(9, 0), LocalTime.of(17, 0), 2);
+    }
+
+    // ── Coverage report ───────────────────────────────────────────────────────
+
+    @Test
+    void getCoverageReport_WithOpenShiftsAndAssignees_ReturnsCorrectEntry() {
+        ShiftAssignment assignment = buildAssignment(1L, shift, employee);
+
+        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of(shift));
+        when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of(assignment));
+
+        CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 20);
+
+        assertThat(response.totalElements()).isEqualTo(1);
+        CoverageReportEntry entry = response.content().getFirst();
+        assertThat(entry.shiftId()).isEqualTo(50L);
+        assertThat(entry.departmentName()).isEqualTo("Kitchen");
+        assertThat(entry.requiredHeadcount()).isEqualTo(2);
+        assertThat(entry.assignedCount()).isEqualTo(1);
+        assertThat(entry.employeeNames()).containsExactly("Alice");
+        assertThat(entry.staffingStatus()).isEqualTo(StaffingStatus.UNDERSTAFFED);
+    }
+
+    @Test
+    void getCoverageReport_CancelledShift_ExcludedFromReport() {
+        shift.setStatus(ShiftStatus.CANCELLED);
+        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of(shift));
+
+        CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 20);
+
+        assertThat(response.totalElements()).isEqualTo(0);
+        assertThat(response.content()).isEmpty();
+    }
+
+    @Test
+    void getCoverageReport_NoShifts_ReturnsEmptyPage() {
+        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of());
+
+        CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 20);
+
+        assertThat(response.totalElements()).isEqualTo(0);
+        assertThat(response.content()).isEmpty();
+        assertThat(response.totalPages()).isEqualTo(0);
+    }
+
+    @Test
+    void getCoverageReport_PaginationSlicesCorrectly() {
+        Shift s2 = buildShift(51L, LocalDate.of(2026, 6, 2), LocalTime.of(10, 0), LocalTime.of(18, 0), 1);
+        Shift s3 = buildShift(52L, LocalDate.of(2026, 6, 3), LocalTime.of(10, 0), LocalTime.of(18, 0), 1);
+
+        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of(shift, s2, s3));
+        when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of());
+
+        CoverageReportPageResponse page0 = reportService.getCoverageReport(10L, FROM, TO, 0, 2);
+        CoverageReportPageResponse page1 = reportService.getCoverageReport(10L, FROM, TO, 1, 2);
+
+        assertThat(page0.content()).hasSize(2);
+        assertThat(page0.totalElements()).isEqualTo(3);
+        assertThat(page0.totalPages()).isEqualTo(2);
+        assertThat(page1.content()).hasSize(1);
+    }
+
+    @Test
+    void getCoverageReport_AssignedEqualsMinimum_ReturnsFullyStaffed() {
+        User u2 = User.builder().id(2L).fullName("Bob").role(UserRole.EMPLOYEE).build();
+        ShiftAssignment a1 = buildAssignment(1L, shift, employee);
+        ShiftAssignment a2 = buildAssignment(2L, shift, buildEmployee(200L, u2));
+
+        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of(shift));
+        when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of(a1, a2));
+
+        CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 20);
+
+        assertThat(response.content().getFirst().staffingStatus()).isEqualTo(StaffingStatus.FULLY_STAFFED);
+    }
+
+    @Test
+    void getCoverageReport_AssignedExceedsMinimum_ReturnsOverstaffed() {
+        User u2 = User.builder().id(2L).fullName("Bob").role(UserRole.EMPLOYEE).build();
+        User u3 = User.builder().id(3L).fullName("Carol").role(UserRole.EMPLOYEE).build();
+        ShiftAssignment a1 = buildAssignment(1L, shift, employee);
+        ShiftAssignment a2 = buildAssignment(2L, shift, buildEmployee(200L, u2));
+        ShiftAssignment a3 = buildAssignment(3L, shift, buildEmployee(300L, u3));
+
+        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of(shift));
+        when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of(a1, a2, a3));
+
+        CoverageReportPageResponse response = reportService.getCoverageReport(10L, FROM, TO, 0, 20);
+
+        assertThat(response.content().getFirst().staffingStatus()).isEqualTo(StaffingStatus.OVERSTAFFED);
+        assertThat(response.content().getFirst().assignedCount()).isEqualTo(3);
+    }
+
+    @Test
+    void getCoverageReport_FromAfterTo_ThrowsBadRequest() {
+        assertThatThrownBy(() -> reportService.getCoverageReport(10L, TO, FROM, 0, 20))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("'from' date must not be after 'to' date");
+    }
+
+    @Test
+    void getAllCoverageEntries_ReturnsAllEntriesWithoutPagination() {
+        when(shiftRepository.findByLocationInRange(10L, FROM, TO)).thenReturn(List.of(shift));
+        when(shiftAssignmentRepository.findAssignmentsByShiftIds(any())).thenReturn(List.of());
+
+        List<CoverageReportEntry> entries = reportService.getAllCoverageEntries(10L, FROM, TO);
+
+        assertThat(entries).hasSize(1);
+        assertThat(entries.getFirst().shiftId()).isEqualTo(50L);
+    }
+
+    // ── Overtime report ───────────────────────────────────────────────────────
+
+    @Test
+    void getOvertimeReport_EmployeeExceedsContractedHours_ReturnsOvertimeEntry() {
+        // contractedWeeklyHours=10, period=7 days → expected=10h; two 8h shifts=16h → overage=6h
+        Shift s2 = buildShift(51L, LocalDate.of(2026, 6, 2), LocalTime.of(9, 0), LocalTime.of(17, 0), 1);
+        ShiftAssignment a1 = buildAssignment(1L, shift, employee);
+        ShiftAssignment a2 = buildAssignment(2L, s2, employee);
+
+        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, ShiftStatus.CANCELLED, null))
+                .thenReturn(List.of(a1, a2));
+
+        OvertimeReportPageResponse response = reportService.getOvertimeReport(null, FROM, TO, 0, 20);
+
+        assertThat(response.totalElements()).isEqualTo(1);
+        OvertimeReportEntry entry = response.content().getFirst();
+        assertThat(entry.employeeName()).isEqualTo("Alice");
+        assertThat(entry.contractedWeeklyHours()).isEqualByComparingTo("10.00");
+        assertThat(entry.actualHoursInPeriod()).isEqualByComparingTo("16.00");
+        assertThat(entry.overtimeHours()).isGreaterThan(BigDecimal.ZERO);
+        assertThat(entry.contributingShifts()).hasSize(2);
+    }
+
+    @Test
+    void getOvertimeReport_EmployeeWithinContractedHours_ExcludedFromReport() {
+        // contractedWeeklyHours=10, period=7 days → expected=10h; one 8h shift=8h < 10h
+        ShiftAssignment a1 = buildAssignment(1L, shift, employee);
+
+        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, ShiftStatus.CANCELLED, null))
+                .thenReturn(List.of(a1));
+
+        OvertimeReportPageResponse response = reportService.getOvertimeReport(null, FROM, TO, 0, 20);
+
+        assertThat(response.totalElements()).isEqualTo(0);
+        assertThat(response.content()).isEmpty();
+    }
+
+    @Test
+    void getOvertimeReport_SortedByOvertimeHoursDescending() {
+        // Alice: 3 × 8h = 24h → overage 14h; Bob: 2 × 8h = 16h → overage 6h
+        User userB = User.builder().id(2L).fullName("Bob").role(UserRole.EMPLOYEE).build();
+        Employee employeeB = buildEmployee(200L, userB);
+        Shift s2 = buildShift(51L, LocalDate.of(2026, 6, 2), LocalTime.of(9, 0), LocalTime.of(17, 0), 1);
+        Shift s3 = buildShift(52L, LocalDate.of(2026, 6, 3), LocalTime.of(9, 0), LocalTime.of(17, 0), 1);
+        Shift s4 = buildShift(53L, LocalDate.of(2026, 6, 4), LocalTime.of(9, 0), LocalTime.of(17, 0), 1);
+
+        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, ShiftStatus.CANCELLED, null))
+                .thenReturn(List.of(
+                        buildAssignment(1L, shift, employee),
+                        buildAssignment(2L, s2, employee),
+                        buildAssignment(3L, s3, employee),
+                        buildAssignment(4L, s3, employeeB),
+                        buildAssignment(5L, s4, employeeB)
+                ));
+
+        OvertimeReportPageResponse response = reportService.getOvertimeReport(null, FROM, TO, 0, 20);
+
+        assertThat(response.totalElements()).isEqualTo(2);
+        assertThat(response.content().get(0).employeeName()).isEqualTo("Alice");
+        assertThat(response.content().get(1).employeeName()).isEqualTo("Bob");
+        assertThat(response.content().get(0).overtimeHours())
+                .isGreaterThan(response.content().get(1).overtimeHours());
+    }
+
+    @Test
+    void getOvertimeReport_NoAssignments_ReturnsEmptyPage() {
+        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, ShiftStatus.CANCELLED, null))
+                .thenReturn(List.of());
+
+        OvertimeReportPageResponse response = reportService.getOvertimeReport(null, FROM, TO, 0, 20);
+
+        assertThat(response.totalElements()).isEqualTo(0);
+        assertThat(response.content()).isEmpty();
+    }
+
+    @Test
+    void getOvertimeReport_ContributingShiftsSortedByDate() {
+        Shift earlier = buildShift(51L, LocalDate.of(2026, 6, 3), LocalTime.of(9, 0), LocalTime.of(17, 0), 1);
+        Shift later   = buildShift(52L, LocalDate.of(2026, 6, 5), LocalTime.of(9, 0), LocalTime.of(17, 0), 1);
+
+        when(shiftAssignmentRepository.findAllInDateRangeByOptionalLocation(FROM, TO, ShiftStatus.CANCELLED, null))
+                .thenReturn(List.of(
+                        buildAssignment(1L, shift, employee),
+                        buildAssignment(2L, later, employee),
+                        buildAssignment(3L, earlier, employee)
+                ));
+
+        OvertimeReportPageResponse response = reportService.getOvertimeReport(null, FROM, TO, 0, 20);
+
+        List<OvertimeShiftEntry> shifts = response.content().getFirst().contributingShifts();
+        assertThat(shifts.get(0).date()).isEqualTo(LocalDate.of(2026, 6, 1));
+        assertThat(shifts.get(1).date()).isEqualTo(LocalDate.of(2026, 6, 3));
+        assertThat(shifts.get(2).date()).isEqualTo(LocalDate.of(2026, 6, 5));
+    }
+
+    @Test
+    void getOvertimeReport_FromAfterTo_ThrowsBadRequest() {
+        assertThatThrownBy(() -> reportService.getOvertimeReport(null, TO, FROM, 0, 20))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("'from' date must not be after 'to' date");
+    }
+
+    // ── Leave utilization report ──────────────────────────────────────────────
+
+    @Test
+    void getLeaveReport_ApprovedAnnualLeave_ReturnsCorrectDayCount() {
+        // Leave: FROM (2026-06-01) to 2026-06-05 = 5 days
+        LeaveRequest leave = buildLeave(1L, employee, FROM, TO.minusDays(2), LeaveType.ANNUAL);
+
+        when(leaveRequestRepository.findByStatusInRangeByOptionalLocation(FROM, TO, LeaveStatus.APPROVED, null))
+                .thenReturn(List.of(leave));
+
+        LeaveUtilizationReportResponse response = reportService.getLeaveReport(null, FROM, TO, 0, 20);
+
+        assertThat(response.employees()).hasSize(1);
+        LeaveEmployeeEntry entry = response.employees().getFirst();
+        assertThat(entry.employeeName()).isEqualTo("Alice");
+        assertThat(entry.departmentName()).isEqualTo("Kitchen");
+        assertThat(entry.annualDaysTaken()).isEqualTo(5);
+        assertThat(entry.sickDaysTaken()).isEqualTo(0);
+        assertThat(entry.totalDaysTaken()).isEqualTo(5);
+    }
+
+    @Test
+    void getLeaveReport_LeaveStartsBeforePeriod_ClipsToPeriodStart() {
+        // Leave: 2026-05-29 to 2026-06-04; period: 2026-06-01 to 2026-06-07
+        // Effective: 2026-06-01 to 2026-06-04 = 4 days
+        LeaveRequest leave = buildLeave(1L, employee, FROM.minusDays(3), FROM.plusDays(3), LeaveType.SICK);
+
+        when(leaveRequestRepository.findByStatusInRangeByOptionalLocation(FROM, TO, LeaveStatus.APPROVED, null))
+                .thenReturn(List.of(leave));
+
+        LeaveUtilizationReportResponse response = reportService.getLeaveReport(null, FROM, TO, 0, 20);
+
+        assertThat(response.employees().getFirst().sickDaysTaken()).isEqualTo(4);
+    }
+
+    @Test
+    void getLeaveReport_MultipleLeaveTypes_SummedPerType() {
+        // ANNUAL: 2026-06-01 to 2026-06-02 = 2 days
+        // SICK:   2026-06-04 to 2026-06-05 = 2 days
+        // UNPAID: 2026-06-06 to 2026-06-06 = 1 day
+        LeaveRequest annual = buildLeave(1L, employee, FROM, FROM.plusDays(1), LeaveType.ANNUAL);
+        LeaveRequest sick   = buildLeave(2L, employee, FROM.plusDays(3), FROM.plusDays(4), LeaveType.SICK);
+        LeaveRequest unpaid = buildLeave(3L, employee, FROM.plusDays(5), FROM.plusDays(5), LeaveType.UNPAID);
+
+        when(leaveRequestRepository.findByStatusInRangeByOptionalLocation(FROM, TO, LeaveStatus.APPROVED, null))
+                .thenReturn(List.of(annual, sick, unpaid));
+
+        LeaveEmployeeEntry entry = reportService.getLeaveReport(null, FROM, TO, 0, 20).employees().getFirst();
+
+        assertThat(entry.annualDaysTaken()).isEqualTo(2);
+        assertThat(entry.sickDaysTaken()).isEqualTo(2);
+        assertThat(entry.unpaidDaysTaken()).isEqualTo(1);
+        assertThat(entry.totalDaysTaken()).isEqualTo(5);
+    }
+
+    @Test
+    void getLeaveReport_DepartmentAggregatesIncludeAllEmployees() {
+        User userB = User.builder().id(2L).fullName("Bob").role(UserRole.EMPLOYEE).build();
+        Employee employeeB = buildEmployee(200L, userB);
+
+        // Alice: 2 days ANNUAL; Bob: 2 days SICK
+        LeaveRequest leaveA = buildLeave(1L, employee,  FROM, FROM.plusDays(1), LeaveType.ANNUAL);
+        LeaveRequest leaveB = buildLeave(2L, employeeB, FROM.plusDays(2), FROM.plusDays(3), LeaveType.SICK);
+
+        when(leaveRequestRepository.findByStatusInRangeByOptionalLocation(FROM, TO, LeaveStatus.APPROVED, null))
+                .thenReturn(List.of(leaveA, leaveB));
+
+        LeaveUtilizationReportResponse response = reportService.getLeaveReport(null, FROM, TO, 0, 20);
+
+        assertThat(response.departmentAggregates()).hasSize(1);
+        DepartmentLeaveAggregate agg = response.departmentAggregates().getFirst();
+        assertThat(agg.departmentName()).isEqualTo("Kitchen");
+        assertThat(agg.annualDaysTaken()).isEqualTo(2);
+        assertThat(agg.sickDaysTaken()).isEqualTo(2);
+        assertThat(agg.totalDaysTaken()).isEqualTo(4);
+    }
+
+    @Test
+    void getLeaveReport_DepartmentAggregatesAlwaysFullRegardlessOfPage() {
+        User userB = User.builder().id(2L).fullName("Bob").role(UserRole.EMPLOYEE).build();
+        User userC = User.builder().id(3L).fullName("Carol").role(UserRole.EMPLOYEE).build();
+        LeaveRequest leaveA = buildLeave(1L, employee,               FROM, FROM, LeaveType.ANNUAL);
+        LeaveRequest leaveB = buildLeave(2L, buildEmployee(200L, userB), FROM, FROM, LeaveType.ANNUAL);
+        LeaveRequest leaveC = buildLeave(3L, buildEmployee(300L, userC), FROM, FROM, LeaveType.ANNUAL);
+
+        when(leaveRequestRepository.findByStatusInRangeByOptionalLocation(FROM, TO, LeaveStatus.APPROVED, null))
+                .thenReturn(List.of(leaveA, leaveB, leaveC));
+
+        LeaveUtilizationReportResponse page0 = reportService.getLeaveReport(null, FROM, TO, 0, 2);
+        LeaveUtilizationReportResponse page1 = reportService.getLeaveReport(null, FROM, TO, 1, 2);
+
+        assertThat(page0.employees()).hasSize(2);
+        assertThat(page0.totalElements()).isEqualTo(3);
+        assertThat(page0.totalPages()).isEqualTo(2);
+        assertThat(page1.employees()).hasSize(1);
+        assertThat(page0.departmentAggregates()).hasSize(1);
+        assertThat(page1.departmentAggregates()).hasSize(1);
+    }
+
+    @Test
+    void getLeaveReport_NoApprovedLeave_ReturnsEmptyResponse() {
+        when(leaveRequestRepository.findByStatusInRangeByOptionalLocation(FROM, TO, LeaveStatus.APPROVED, null))
+                .thenReturn(List.of());
+
+        LeaveUtilizationReportResponse response = reportService.getLeaveReport(null, FROM, TO, 0, 20);
+
+        assertThat(response.employees()).isEmpty();
+        assertThat(response.departmentAggregates()).isEmpty();
+        assertThat(response.totalElements()).isEqualTo(0);
+    }
+
+    @Test
+    void getLeaveReport_FromAfterTo_ThrowsBadRequest() {
+        assertThatThrownBy(() -> reportService.getLeaveReport(null, TO, FROM, 0, 20))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("'from' date must not be after 'to' date");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private Shift buildShift(Long id, LocalDate date, LocalTime start, LocalTime end, int minHeadcount) {
+        return Shift.builder()
+                .id(id).location(location).department(department)
+                .shiftDate(date).startTime(start).endTime(end)
+                .minimumHeadcount(minHeadcount).status(ShiftStatus.OPEN)
+                .createdBy(user)
+                .build();
+    }
+
+    private ShiftAssignment buildAssignment(Long id, Shift s, Employee emp) {
+        return ShiftAssignment.builder()
+                .id(id).shift(s).employee(emp).assignedBy(user).overrideApplied(false)
+                .build();
+    }
+
+    private Employee buildEmployee(Long id, User u) {
+        return Employee.builder()
+                .id(id).user(u)
+                .location(location).department(department)
+                .employmentType(EmploymentType.FULL_TIME)
+                .contractedWeeklyHours(new BigDecimal("10.00"))
+                .hireDate(LocalDate.of(2025, 1, 1))
+                .active(true).notificationEnabled(true)
+                .build();
+    }
+
+    private LeaveRequest buildLeave(Long id, Employee emp, LocalDate start, LocalDate end, LeaveType type) {
+        return LeaveRequest.builder()
+                .id(id).employee(emp)
+                .startDate(start).endDate(end)
+                .leaveType(type).status(LeaveStatus.APPROVED)
+                .build();
+    }
+}


### PR DESCRIPTION
## What
Implements Epic 8 — three reporting endpoints with JSON (paginated) and CSV export variants:
- `GET /api/v1/reports/coverage` — shift staffing coverage per location and date range (FR-RPT-01)
- `GET /api/v1/reports/overtime` — employees who exceeded contracted hours in a pay period (FR-RPT-02)
- `GET /api/v1/reports/leave` — per-employee leave breakdown with department-level aggregates (FR-RPT-03)

## Why
Managers and HR Admins need visibility into staffing gaps, overtime exposure, and leave patterns. The coverage report helps managers identify understaffed shifts before they become a problem; overtime and leave reports give HR Admins data for payroll and workforce planning.

## How to test
1. Log in as `MANAGER` or `HR_ADMIN`, call `GET /api/v1/reports/coverage?locationId=1&from=2026-01-01&to=2026-01-31` — expect paginated shift entries with staffing status (`UNDERSTAFFED`, `FULLY_STAFFED`, `OVERSTAFFED`)
2. Repeat the same request with `Accept: text/csv` — expect a downloadable CSV attachment
3. Log in as `HR_ADMIN`, call `GET /api/v1/reports/overtime?from=2026-01-01&to=2026-01-31` — expect only employees whose actual hours exceed contracted weekly hours (prorated to the period), sorted by overage descending
4. Call `GET /api/v1/reports/leave?from=2026-01-01&to=2026-01-31` — expect per-employee annual/sick/unpaid day counts plus department aggregate totals; aggregates must be complete regardless of which page is requested
5. Verify `MANAGER` role receives `403` on `overtime` and `leave` endpoints
6. Pass `from` after `to` on any endpoint — expect `400 Bad Request`

## Notes
- All three endpoints use content negotiation on the same path — `Accept: application/json` returns paginated JSON, `Accept: text/csv` returns a full export with no pagination.
- Coverage leave data is clipped to the requested date range (e.g. a leave spanning across the period boundary only counts days that fall within `from`–`to`).
- Coverage access reuses `ShiftService.verifyManagerLocationAccess` — managers are restricted to their assigned locations; HR Admins see all.
- Overtime expected hours are prorated: `contractedWeeklyHours × daysInPeriod / 7`.
