### PR TITLE
feat: add AOP-based audit logging infrastructure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
-            <version>3.5.14</version>
+            <version>4.0.0-M2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+            <version>3.5.14</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/com/shiftsync/shiftsync/audit/annotation/Auditable.java
+++ b/src/main/java/com/shiftsync/shiftsync/audit/annotation/Auditable.java
@@ -1,0 +1,23 @@
+package com.shiftsync.shiftsync.audit.annotation;
+
+import com.shiftsync.shiftsync.common.enums.AuditAction;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Auditable {
+
+    String entityType();
+
+    AuditAction action();
+
+    /**
+     * Zero-based index of the method parameter that holds the entity ID.
+     * Use -1 (default) to extract the ID from the return value instead.
+     */
+    int entityIdParam() default -1;
+}

--- a/src/main/java/com/shiftsync/shiftsync/audit/aspect/AuditAspect.java
+++ b/src/main/java/com/shiftsync/shiftsync/audit/aspect/AuditAspect.java
@@ -1,0 +1,109 @@
+package com.shiftsync.shiftsync.audit.aspect;
+
+import com.shiftsync.shiftsync.audit.annotation.Auditable;
+import com.shiftsync.shiftsync.audit.entity.AuditLog;
+import com.shiftsync.shiftsync.audit.service.AuditLogService;
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.auth.repository.UserRepository;
+import com.shiftsync.shiftsync.common.enums.AuditAction;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Optional;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AuditAspect {
+
+    private final AuditLogService auditLogService;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    @Around("@annotation(auditable)")
+    public Object audit(ProceedingJoinPoint jp, Auditable auditable) throws Throwable {
+        Object result = jp.proceed();
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || !(auth.getPrincipal() instanceof Long actorId)) {
+            return result;
+        }
+
+        Optional<User> actorOpt = userRepository.findById(actorId);
+        if (actorOpt.isEmpty()) {
+            return result;
+        }
+
+        UserRole actorRole = extractRole(auth);
+        Long entityId = resolveEntityId(jp.getArgs(), auditable, result);
+        String afterState = resolveAfterState(auditable.action(), result);
+
+        AuditLog auditLog = AuditLog.builder()
+                .entityType(auditable.entityType())
+                .entityId(entityId)
+                .action(auditable.action())
+                .actor(actorOpt.get())
+                .actorRole(actorRole)
+                .afterState(afterState)
+                .build();
+
+        auditLogService.save(auditLog);
+
+        return result;
+    }
+
+    private UserRole extractRole(Authentication auth) {
+        return auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(a -> a.startsWith("ROLE_"))
+                .map(a -> a.replace("ROLE_", ""))
+                .map(UserRole::valueOf)
+                .findFirst()
+                .orElse(UserRole.EMPLOYEE);
+    }
+
+    private Long resolveEntityId(Object[] args, Auditable auditable, Object result) {
+        if (auditable.entityIdParam() >= 0 && args != null && auditable.entityIdParam() < args.length) {
+            Object param = args[auditable.entityIdParam()];
+            if (param instanceof Long id) {
+                return id;
+            }
+        }
+        return extractIdFromResult(result);
+    }
+
+    private Long extractIdFromResult(Object result) {
+        if (result == null) {
+            return null;
+        }
+        for (String methodName : new String[]{"getId", "id", "employeeId", "assignmentId"}) {
+            try {
+                Object value = result.getClass().getMethod(methodName).invoke(result);
+                if (value instanceof Long id) {
+                    return id;
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return null;
+    }
+
+    private String resolveAfterState(AuditAction action, Object result) {
+        if (action == AuditAction.DELETE || result == null) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(result);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/audit/controller/AuditLogController.java
+++ b/src/main/java/com/shiftsync/shiftsync/audit/controller/AuditLogController.java
@@ -1,0 +1,54 @@
+package com.shiftsync.shiftsync.audit.controller;
+
+import com.shiftsync.shiftsync.audit.dto.AuditLogPageResponse;
+import com.shiftsync.shiftsync.audit.service.AuditLogService;
+import com.shiftsync.shiftsync.common.response.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/v1/audit-logs")
+@RequiredArgsConstructor
+@Tag(name = "Audit Logs", description = "Immutable audit trail of all write operations")
+public class AuditLogController {
+
+    private final AuditLogService auditLogService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('HR_ADMIN')")
+    @Operation(
+            summary = "Query audit logs",
+            description = "Returns a paginated, newest-first audit log filtered by entity type (required), entity ID, actor, and date range. Only HR Admins may access this endpoint."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Audit log entries returned", content = @Content(schema = @Schema(implementation = AuditLogPageResponse.class))),
+            @ApiResponse(responseCode = "400", description = "entityType filter is required", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<AuditLogPageResponse> queryAuditLogs(
+            @RequestParam String entityType,
+            @RequestParam(required = false) Long entityId,
+            @RequestParam(required = false) Long actorId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(auditLogService.query(entityType, entityId, actorId, from, to, page, size));
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/audit/dto/AuditLogPageResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/audit/dto/AuditLogPageResponse.java
@@ -1,0 +1,11 @@
+package com.shiftsync.shiftsync.audit.dto;
+
+import java.util.List;
+
+public record AuditLogPageResponse(
+        List<AuditLogResponse> content,
+        long totalElements,
+        int totalPages,
+        int currentPage
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/audit/dto/AuditLogResponse.java
+++ b/src/main/java/com/shiftsync/shiftsync/audit/dto/AuditLogResponse.java
@@ -1,0 +1,20 @@
+package com.shiftsync.shiftsync.audit.dto;
+
+import com.shiftsync.shiftsync.common.enums.AuditAction;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+
+import java.time.LocalDateTime;
+
+public record AuditLogResponse(
+        Long id,
+        String entityType,
+        Long entityId,
+        AuditAction action,
+        Long actorId,
+        String actorName,
+        UserRole actorRole,
+        String beforeState,
+        String afterState,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/shiftsync/shiftsync/audit/entity/AuditLog.java
+++ b/src/main/java/com/shiftsync/shiftsync/audit/entity/AuditLog.java
@@ -1,0 +1,57 @@
+package com.shiftsync.shiftsync.audit.entity;
+
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.common.enums.AuditAction;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnTransformer;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "audit_logs")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "entity_type", nullable = false, length = 100)
+    private String entityType;
+
+    @Column(name = "entity_id", nullable = false)
+    private Long entityId;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "?::audit_action")
+    @Column(nullable = false)
+    private AuditAction action;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_id", nullable = false)
+    private User actor;
+
+    @Enumerated(EnumType.STRING)
+    @ColumnTransformer(write = "?::user_role")
+    @Column(name = "actor_role", nullable = false)
+    private UserRole actorRole;
+
+    @Column(name = "before_state", columnDefinition = "jsonb")
+    private String beforeState;
+
+    @Column(name = "after_state", columnDefinition = "jsonb")
+    private String afterState;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/audit/repository/AuditLogRepository.java
+++ b/src/main/java/com/shiftsync/shiftsync/audit/repository/AuditLogRepository.java
@@ -1,0 +1,8 @@
+package com.shiftsync.shiftsync.audit.repository;
+
+import com.shiftsync.shiftsync.audit.entity.AuditLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long>, JpaSpecificationExecutor<AuditLog> {
+}

--- a/src/main/java/com/shiftsync/shiftsync/audit/service/AuditLogService.java
+++ b/src/main/java/com/shiftsync/shiftsync/audit/service/AuditLogService.java
@@ -1,0 +1,14 @@
+package com.shiftsync.shiftsync.audit.service;
+
+import com.shiftsync.shiftsync.audit.dto.AuditLogPageResponse;
+import com.shiftsync.shiftsync.audit.entity.AuditLog;
+
+import java.time.LocalDateTime;
+
+public interface AuditLogService {
+
+    void save(AuditLog auditLog);
+
+    AuditLogPageResponse query(String entityType, Long entityId, Long actorId,
+                               LocalDateTime from, LocalDateTime to, int page, int size);
+}

--- a/src/main/java/com/shiftsync/shiftsync/audit/service/impl/AuditLogServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/audit/service/impl/AuditLogServiceImpl.java
@@ -1,0 +1,75 @@
+package com.shiftsync.shiftsync.audit.service.impl;
+
+import com.shiftsync.shiftsync.audit.dto.AuditLogPageResponse;
+import com.shiftsync.shiftsync.audit.dto.AuditLogResponse;
+import com.shiftsync.shiftsync.audit.entity.AuditLog;
+import com.shiftsync.shiftsync.audit.repository.AuditLogRepository;
+import com.shiftsync.shiftsync.audit.service.AuditLogService;
+import com.shiftsync.shiftsync.audit.specification.AuditLogSpecification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class AuditLogServiceImpl implements AuditLogService {
+
+    private final AuditLogRepository auditLogRepository;
+
+    @Override
+    @Transactional
+    public void save(AuditLog auditLog) {
+        auditLogRepository.save(auditLog);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AuditLogPageResponse query(String entityType, Long entityId, Long actorId,
+                                      LocalDateTime from, LocalDateTime to, int page, int size) {
+        Specification<AuditLog> spec = Specification.where(AuditLogSpecification.hasEntityType(entityType));
+
+        if (entityId != null) {
+            spec = spec.and(AuditLogSpecification.hasEntityId(entityId));
+        }
+        if (actorId != null) {
+            spec = spec.and(AuditLogSpecification.hasActorId(actorId));
+        }
+        if (from != null) {
+            spec = spec.and(AuditLogSpecification.createdAfter(from));
+        }
+        if (to != null) {
+            spec = spec.and(AuditLogSpecification.createdBefore(to));
+        }
+
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<AuditLog> result = auditLogRepository.findAll(spec, pageable);
+
+        return new AuditLogPageResponse(
+                result.getContent().stream().map(this::toResponse).toList(),
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.getNumber()
+        );
+    }
+
+    private AuditLogResponse toResponse(AuditLog log) {
+        return new AuditLogResponse(
+                log.getId(),
+                log.getEntityType(),
+                log.getEntityId(),
+                log.getAction(),
+                log.getActor().getId(),
+                log.getActor().getFullName(),
+                log.getActorRole(),
+                log.getBeforeState(),
+                log.getAfterState(),
+                log.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/audit/specification/AuditLogSpecification.java
+++ b/src/main/java/com/shiftsync/shiftsync/audit/specification/AuditLogSpecification.java
@@ -1,0 +1,31 @@
+package com.shiftsync.shiftsync.audit.specification;
+
+import com.shiftsync.shiftsync.audit.entity.AuditLog;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+
+public class AuditLogSpecification {
+
+    private AuditLogSpecification() {}
+
+    public static Specification<AuditLog> hasEntityType(String entityType) {
+        return (root, _, cb) -> cb.equal(root.get("entityType"), entityType);
+    }
+
+    public static Specification<AuditLog> hasEntityId(Long entityId) {
+        return (root, _, cb) -> cb.equal(root.get("entityId"), entityId);
+    }
+
+    public static Specification<AuditLog> hasActorId(Long actorId) {
+        return (root, _, cb) -> cb.equal(root.get("actor").get("id"), actorId);
+    }
+
+    public static Specification<AuditLog> createdAfter(LocalDateTime from) {
+        return (root, _, cb) -> cb.greaterThanOrEqualTo(root.get("createdAt"), from);
+    }
+
+    public static Specification<AuditLog> createdBefore(LocalDateTime to) {
+        return (root, _, cb) -> cb.lessThanOrEqualTo(root.get("createdAt"), to);
+    }
+}

--- a/src/main/java/com/shiftsync/shiftsync/common/enums/AuditAction.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/enums/AuditAction.java
@@ -1,0 +1,7 @@
+package com.shiftsync.shiftsync.common.enums;
+
+public enum AuditAction {
+    CREATE,
+    UPDATE,
+    DELETE
+}

--- a/src/main/java/com/shiftsync/shiftsync/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/shiftsync/shiftsync/common/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -39,6 +40,17 @@ public class GlobalExceptionHandler {
                 fieldErrors
         );
 
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingRequestParam(MissingServletRequestParameterException ex) {
+        log.warn("Missing required request parameter: {}", ex.getParameterName());
+        ErrorResponse response = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad Request",
+                "Required parameter '" + ex.getParameterName() + "' is missing"
+        );
         return ResponseEntity.badRequest().body(response);
     }
 

--- a/src/main/java/com/shiftsync/shiftsync/config/security/SecurityConfig.java
+++ b/src/main/java/com/shiftsync/shiftsync/config/security/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").hasRole("HR_ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/v1/employees").hasRole("HR_ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/v1/employees").hasAnyRole("HR_ADMIN", "MANAGER")
+                        .requestMatchers("/api/v1/audit-logs/**").hasRole("HR_ADMIN")
                         .anyRequest().authenticated()
                 )
                 .authenticationProvider(authenticationProvider())

--- a/src/main/java/com/shiftsync/shiftsync/employee/service/EmployeeService.java
+++ b/src/main/java/com/shiftsync/shiftsync/employee/service/EmployeeService.java
@@ -1,5 +1,7 @@
 package com.shiftsync.shiftsync.employee.service;
 
+import com.shiftsync.shiftsync.audit.annotation.Auditable;
+import com.shiftsync.shiftsync.common.enums.AuditAction;
 import com.shiftsync.shiftsync.employee.dto.CreateEmployeeRequest;
 import com.shiftsync.shiftsync.employee.dto.EmployeePageResponse;
 import com.shiftsync.shiftsync.employee.dto.EmployeeResponse;
@@ -17,6 +19,7 @@ public interface EmployeeService {
      * @param request the request
      * @return the employee response
      */
+    @Auditable(entityType = "EMPLOYEE", action = AuditAction.CREATE)
     EmployeeResponse createEmployee(CreateEmployeeRequest request);
 
     /**
@@ -42,6 +45,7 @@ public interface EmployeeService {
      * @param request     the request
      * @return the employee response
      */
+    @Auditable(entityType = "EMPLOYEE", action = AuditAction.UPDATE, entityIdParam = 0)
     EmployeeResponse updateMyProfile(Long actorUserId, UpdateMyProfileRequest request);
 
     /**
@@ -60,6 +64,7 @@ public interface EmployeeService {
      * @param employeeId the employee id
      * @return the employee response
      */
+    @Auditable(entityType = "EMPLOYEE", action = AuditAction.UPDATE, entityIdParam = 0)
     EmployeeResponse deactivateEmployee(Long employeeId);
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
+++ b/src/main/java/com/shiftsync/shiftsync/leave/service/LeaveRequestService.java
@@ -1,5 +1,7 @@
 package com.shiftsync.shiftsync.leave.service;
 
+import com.shiftsync.shiftsync.audit.annotation.Auditable;
+import com.shiftsync.shiftsync.common.enums.AuditAction;
 import com.shiftsync.shiftsync.leave.dto.ApproveLeaveRequest;
 import com.shiftsync.shiftsync.leave.dto.CreateLeaveRequest;
 import com.shiftsync.shiftsync.leave.dto.GetLeaveRequestsRequest;
@@ -19,6 +21,7 @@ public interface LeaveRequestService {
      * @param request     the request
      * @return the leave request response
      */
+    @Auditable(entityType = "LEAVE_REQUEST", action = AuditAction.CREATE)
     LeaveRequestResponse createLeaveRequest(Long actorUserId, CreateLeaveRequest request);
 
     /**
@@ -29,6 +32,7 @@ public interface LeaveRequestService {
      * @param request        the request
      * @return the leave request response
      */
+    @Auditable(entityType = "LEAVE_REQUEST", action = AuditAction.UPDATE, entityIdParam = 1)
     LeaveRequestResponse approveLeaveRequest(Long actorUserId, Long leaveRequestId, ApproveLeaveRequest request);
 
     /**
@@ -39,6 +43,7 @@ public interface LeaveRequestService {
      * @param request        the request
      * @return the leave request response
      */
+    @Auditable(entityType = "LEAVE_REQUEST", action = AuditAction.UPDATE, entityIdParam = 1)
     LeaveRequestResponse rejectLeaveRequest(Long actorUserId, Long leaveRequestId, RejectLeaveRequest request);
 
     /**
@@ -48,6 +53,7 @@ public interface LeaveRequestService {
      * @param leaveRequestId the leave request id
      * @return the leave request response
      */
+    @Auditable(entityType = "LEAVE_REQUEST", action = AuditAction.UPDATE, entityIdParam = 1)
     LeaveRequestResponse cancelLeaveRequest(Long actorUserId, Long leaveRequestId);
 
     /**

--- a/src/main/java/com/shiftsync/shiftsync/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/shiftsync/shiftsync/notification/service/impl/NotificationServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -35,7 +36,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async("notificationExecutor")
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onNotificationEvent(NotificationEvent event) {
         Notification notification = Notification.builder()
                 .userId(event.userId())

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftAssignmentService.java
@@ -1,5 +1,7 @@
 package com.shiftsync.shiftsync.shift.service;
 
+import com.shiftsync.shiftsync.audit.annotation.Auditable;
+import com.shiftsync.shiftsync.common.enums.AuditAction;
 import com.shiftsync.shiftsync.shift.dto.AssignEmployeeRequest;
 import com.shiftsync.shiftsync.shift.dto.AssignEmployeeResponse;
 
@@ -17,6 +19,7 @@ public interface ShiftAssignmentService {
      * @param override    the override
      * @return the assign employee response
      */
+    @Auditable(entityType = "SHIFT_ASSIGNMENT", action = AuditAction.CREATE, entityIdParam = 1)
     AssignEmployeeResponse assignEmployee(Long actorUserId, Long shiftId, AssignEmployeeRequest request, boolean override);
 
     /**
@@ -26,6 +29,7 @@ public interface ShiftAssignmentService {
      * @param shiftId     the shift ID
      * @param employeeId  the employee ID to remove
      */
+    @Auditable(entityType = "SHIFT_ASSIGNMENT", action = AuditAction.DELETE, entityIdParam = 1)
     void removeAssignment(Long actorUserId, Long shiftId, Long employeeId);
 }
 

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftService.java
@@ -1,5 +1,7 @@
 package com.shiftsync.shiftsync.shift.service;
 
+import com.shiftsync.shiftsync.audit.annotation.Auditable;
+import com.shiftsync.shiftsync.common.enums.AuditAction;
 import com.shiftsync.shiftsync.shift.dto.CreateShiftRequest;
 import com.shiftsync.shiftsync.shift.dto.EmployeeShiftResponse;
 import com.shiftsync.shiftsync.shift.dto.LocationShiftPageResponse;
@@ -18,6 +20,7 @@ public interface ShiftService {
      * @param request     the shift creation request
      * @return the created shift response
      */
+    @Auditable(entityType = "SHIFT", action = AuditAction.CREATE)
     ShiftResponse createShift(Long actorUserId, CreateShiftRequest request);
 
     /**
@@ -28,6 +31,7 @@ public interface ShiftService {
      * @param request     partial update — only non-null fields are applied
      * @return the updated shift response
      */
+    @Auditable(entityType = "SHIFT", action = AuditAction.UPDATE, entityIdParam = 1)
     ShiftResponse updateShift(Long actorUserId, Long shiftId, UpdateShiftRequest request);
 
     /**
@@ -36,6 +40,7 @@ public interface ShiftService {
      * @param actorUserId the ID of the authenticated user performing the cancel
      * @param shiftId     the shift to cancel
      */
+    @Auditable(entityType = "SHIFT", action = AuditAction.UPDATE, entityIdParam = 1)
     void cancelShift(Long actorUserId, Long shiftId);
 
     /**

--- a/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftSwapService.java
+++ b/src/main/java/com/shiftsync/shiftsync/shift/service/ShiftSwapService.java
@@ -1,5 +1,7 @@
 package com.shiftsync.shiftsync.shift.service;
 
+import com.shiftsync.shiftsync.audit.annotation.Auditable;
+import com.shiftsync.shiftsync.common.enums.AuditAction;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapRequest;
 import com.shiftsync.shiftsync.shift.dto.ShiftSwapResponse;
 import com.shiftsync.shiftsync.shift.entity.ShiftSwapStatus;
@@ -18,6 +20,7 @@ public interface ShiftSwapService {
      * @param request     the request
      * @return the shift swap response
      */
+    @Auditable(entityType = "SHIFT_SWAP", action = AuditAction.CREATE)
     ShiftSwapResponse requestSwap(Long actorUserId, ShiftSwapRequest request);
 
     /**
@@ -26,6 +29,7 @@ public interface ShiftSwapService {
      * @param actorUserId the actor user id
      * @param swapId      the swap id
      */
+    @Auditable(entityType = "SHIFT_SWAP", action = AuditAction.UPDATE, entityIdParam = 1)
     void approveSwap(Long actorUserId, Long swapId);
 
     /**
@@ -35,6 +39,7 @@ public interface ShiftSwapService {
      * @param swapId      the swap id
      * @param managerNote the manager note
      */
+    @Auditable(entityType = "SHIFT_SWAP", action = AuditAction.UPDATE, entityIdParam = 1)
     void rejectSwap(Long actorUserId, Long swapId, String managerNote);
 
     /**

--- a/src/test/java/com/shiftsync/shiftsync/audit/aspect/AuditAspectTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/audit/aspect/AuditAspectTest.java
@@ -1,0 +1,192 @@
+package com.shiftsync.shiftsync.audit.aspect;
+
+import com.shiftsync.shiftsync.audit.annotation.Auditable;
+import com.shiftsync.shiftsync.audit.entity.AuditLog;
+import com.shiftsync.shiftsync.audit.service.AuditLogService;
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.auth.repository.UserRepository;
+import com.shiftsync.shiftsync.common.enums.AuditAction;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuditAspectTest {
+
+    @Mock
+    private AuditLogService auditLogService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private ProceedingJoinPoint joinPoint;
+
+    @Mock
+    private Auditable auditable;
+
+    @InjectMocks
+    private AuditAspect auditAspect;
+
+    private User actor;
+
+    @BeforeEach
+    void setUp() {
+        actor = User.builder()
+                .id(1L)
+                .fullName("Morgan Manager")
+                .email("morgan@shiftsync.com")
+                .role(UserRole.MANAGER)
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void authenticateAs(Long userId, UserRole role) {
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                userId, null, List.of(new SimpleGrantedAuthority("ROLE_" + role.name()))
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    void audit_SuccessfulExecution_SavesAuditLog() throws Throwable {
+        authenticateAs(1L, UserRole.MANAGER);
+        when(auditable.entityType()).thenReturn("SHIFT");
+        when(auditable.action()).thenReturn(AuditAction.CREATE);
+        when(auditable.entityIdParam()).thenReturn(-1);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(actor));
+
+        record ShiftResult(Long id) {}
+        ShiftResult result = new ShiftResult(10L);
+        when(joinPoint.proceed()).thenReturn(result);
+        when(objectMapper.writeValueAsString(result)).thenReturn("{\"id\":10}");
+
+        auditAspect.audit(joinPoint, auditable);
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogService).save(captor.capture());
+
+        AuditLog saved = captor.getValue();
+        assertThat(saved.getEntityType()).isEqualTo("SHIFT");
+        assertThat(saved.getAction()).isEqualTo(AuditAction.CREATE);
+        assertThat(saved.getActor()).isEqualTo(actor);
+        assertThat(saved.getActorRole()).isEqualTo(UserRole.MANAGER);
+        assertThat(saved.getAfterState()).isEqualTo("{\"id\":10}");
+    }
+
+    @Test
+    void audit_MethodThrows_NoAuditEntrySaved() throws Throwable {
+        authenticateAs(1L, UserRole.MANAGER);
+        when(joinPoint.proceed()).thenThrow(new RuntimeException("conflict"));
+
+        assertThatThrownBy(() -> auditAspect.audit(joinPoint, auditable))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("conflict");
+
+        verify(auditLogService, never()).save(any());
+    }
+
+    @Test
+    void audit_NoAuthContext_NoAuditEntrySaved() throws Throwable {
+        SecurityContextHolder.clearContext();
+        when(joinPoint.proceed()).thenReturn("result");
+
+        auditAspect.audit(joinPoint, auditable);
+
+        verify(auditLogService, never()).save(any());
+    }
+
+    @Test
+    void audit_EntityIdFromParameter_UsesParamIndex() throws Throwable {
+        authenticateAs(1L, UserRole.MANAGER);
+        when(auditable.entityType()).thenReturn("SHIFT");
+        when(auditable.action()).thenReturn(AuditAction.UPDATE);
+        when(auditable.entityIdParam()).thenReturn(1);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(actor));
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 42L});
+        when(joinPoint.proceed()).thenReturn(null);
+
+        auditAspect.audit(joinPoint, auditable);
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogService).save(captor.capture());
+        assertThat(captor.getValue().getEntityId()).isEqualTo(42L);
+    }
+
+    @Test
+    void audit_DeleteAction_AfterStateIsNull() throws Throwable {
+        authenticateAs(1L, UserRole.MANAGER);
+        when(auditable.entityType()).thenReturn("SHIFT_ASSIGNMENT");
+        when(auditable.action()).thenReturn(AuditAction.DELETE);
+        when(auditable.entityIdParam()).thenReturn(1);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(actor));
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 5L, 2L});
+        when(joinPoint.proceed()).thenReturn(null);
+
+        auditAspect.audit(joinPoint, auditable);
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogService).save(captor.capture());
+        assertThat(captor.getValue().getAfterState()).isNull();
+        assertThat(captor.getValue().getEntityId()).isEqualTo(5L);
+    }
+
+    @Test
+    void audit_ActorNotFoundInRepository_NoAuditEntrySaved() throws Throwable {
+        authenticateAs(99L, UserRole.MANAGER);
+        when(joinPoint.proceed()).thenReturn("result");
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+
+        auditAspect.audit(joinPoint, auditable);
+
+        verify(auditLogService, never()).save(any());
+    }
+
+    @Test
+    void audit_EntityIdFromReturnValue_ReflectionFallback() throws Throwable {
+        authenticateAs(1L, UserRole.HR_ADMIN);
+        when(auditable.entityType()).thenReturn("EMPLOYEE");
+        when(auditable.action()).thenReturn(AuditAction.CREATE);
+        when(auditable.entityIdParam()).thenReturn(-1);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(actor));
+
+        record EmployeeResult(Long employeeId) {}
+        EmployeeResult result = new EmployeeResult(7L);
+        when(joinPoint.proceed()).thenReturn(result);
+        when(objectMapper.writeValueAsString(result)).thenReturn("{\"employeeId\":7}");
+
+        auditAspect.audit(joinPoint, auditable);
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogService).save(captor.capture());
+        assertThat(captor.getValue().getEntityId()).isEqualTo(7L);
+    }
+}

--- a/src/test/java/com/shiftsync/shiftsync/audit/controller/AuditLogControllerWebMvcTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/audit/controller/AuditLogControllerWebMvcTest.java
@@ -1,0 +1,112 @@
+package com.shiftsync.shiftsync.audit.controller;
+
+import com.shiftsync.shiftsync.audit.dto.AuditLogPageResponse;
+import com.shiftsync.shiftsync.audit.dto.AuditLogResponse;
+import com.shiftsync.shiftsync.audit.service.AuditLogService;
+import com.shiftsync.shiftsync.common.enums.AuditAction;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import com.shiftsync.shiftsync.config.security.CustomUserDetailsService;
+import com.shiftsync.shiftsync.config.security.JwtAuthenticationFilter;
+import com.shiftsync.shiftsync.config.security.JwtService;
+import com.shiftsync.shiftsync.config.security.SecurityConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuditLogController.class)
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class AuditLogControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuditLogService auditLogService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    private AuditLogPageResponse singleEntryPage() {
+        AuditLogResponse entry = new AuditLogResponse(
+                1L, "SHIFT", 10L, AuditAction.CREATE,
+                2L, "Morgan Manager", UserRole.MANAGER,
+                null, "{\"id\":10}", LocalDateTime.now()
+        );
+        return new AuditLogPageResponse(List.of(entry), 1L, 1, 0);
+    }
+
+    @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void queryAuditLogs_HrAdmin_ReturnsOk() throws Exception {
+        when(auditLogService.query(eq("SHIFT"), isNull(), isNull(), isNull(), isNull(), eq(0), eq(20)))
+                .thenReturn(singleEntryPage());
+
+        mockMvc.perform(get("/api/v1/audit-logs").param("entityType", "SHIFT"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].entityType").value("SHIFT"))
+                .andExpect(jsonPath("$.content[0].action").value("CREATE"))
+                .andExpect(jsonPath("$.content[0].actorName").value("Morgan Manager"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void queryAuditLogs_WithOptionalFilters_PassesThemThrough() throws Exception {
+        when(auditLogService.query(eq("EMPLOYEE"), eq(5L), eq(1L), any(), any(), eq(0), eq(20)))
+                .thenReturn(new AuditLogPageResponse(List.of(), 0L, 0, 0));
+
+        mockMvc.perform(get("/api/v1/audit-logs")
+                        .param("entityType", "EMPLOYEE")
+                        .param("entityId", "5")
+                        .param("actorId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0));
+    }
+
+    @Test
+    @WithMockUser(roles = "HR_ADMIN")
+    void queryAuditLogs_MissingEntityType_ReturnsBadRequest() throws Exception {
+        mockMvc.perform(get("/api/v1/audit-logs"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void queryAuditLogs_Unauthenticated_ReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/audit-logs").param("entityType", "SHIFT"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "MANAGER")
+    void queryAuditLogs_ManagerRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/audit-logs").param("entityType", "SHIFT"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "EMPLOYEE")
+    void queryAuditLogs_EmployeeRole_ReturnsForbidden() throws Exception {
+        mockMvc.perform(get("/api/v1/audit-logs").param("entityType", "SHIFT"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/shiftsync/shiftsync/audit/service/AuditLogServiceImplTest.java
+++ b/src/test/java/com/shiftsync/shiftsync/audit/service/AuditLogServiceImplTest.java
@@ -1,0 +1,131 @@
+package com.shiftsync.shiftsync.audit.service;
+
+import com.shiftsync.shiftsync.audit.dto.AuditLogPageResponse;
+import com.shiftsync.shiftsync.audit.entity.AuditLog;
+import com.shiftsync.shiftsync.audit.repository.AuditLogRepository;
+import com.shiftsync.shiftsync.audit.service.impl.AuditLogServiceImpl;
+import com.shiftsync.shiftsync.auth.entity.User;
+import com.shiftsync.shiftsync.common.enums.AuditAction;
+import com.shiftsync.shiftsync.common.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuditLogServiceImplTest {
+
+    @Mock
+    private AuditLogRepository auditLogRepository;
+
+    @InjectMocks
+    private AuditLogServiceImpl auditLogService;
+
+    private User actor;
+    private AuditLog auditLog;
+
+    @BeforeEach
+    void setUp() {
+        actor = User.builder()
+                .id(1L)
+                .fullName("Jordan HR")
+                .email("jordan@shiftsync.com")
+                .role(UserRole.HR_ADMIN)
+                .build();
+
+        auditLog = AuditLog.builder()
+                .entityType("SHIFT")
+                .entityId(10L)
+                .action(AuditAction.CREATE)
+                .actor(actor)
+                .actorRole(UserRole.HR_ADMIN)
+                .afterState("{\"id\":10}")
+                .build();
+    }
+
+    @Test
+    void save_PersistsAuditLog() {
+        auditLogService.save(auditLog);
+
+        ArgumentCaptor<AuditLog> captor = ArgumentCaptor.forClass(AuditLog.class);
+        verify(auditLogRepository).save(captor.capture());
+        assertThat(captor.getValue().getEntityType()).isEqualTo("SHIFT");
+        assertThat(captor.getValue().getAction()).isEqualTo(AuditAction.CREATE);
+    }
+
+    @Test
+    void query_WithEntityTypeOnly_ReturnsPage() {
+        Page<AuditLog> page = new PageImpl<>(List.of(auditLog));
+        when(auditLogRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
+
+        AuditLogPageResponse response = auditLogService.query("SHIFT", null, null, null, null, 0, 20);
+
+        assertThat(response.content()).hasSize(1);
+        assertThat(response.content().getFirst().entityType()).isEqualTo("SHIFT");
+        assertThat(response.content().getFirst().actorName()).isEqualTo("Jordan HR");
+        assertThat(response.totalElements()).isEqualTo(1);
+        assertThat(response.currentPage()).isEqualTo(0);
+    }
+
+    @Test
+    void query_WithAllFilters_PassesSpecificationToRepository() {
+        Page<AuditLog> page = new PageImpl<>(List.of(auditLog));
+        when(auditLogRepository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(page);
+
+        LocalDateTime from = LocalDateTime.now().minusDays(7);
+        LocalDateTime to = LocalDateTime.now();
+
+        AuditLogPageResponse response = auditLogService.query("SHIFT", 10L, 1L, from, to, 0, 10);
+
+        assertThat(response.content()).hasSize(1);
+        verify(auditLogRepository).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    void query_EmptyResult_ReturnsEmptyPage() {
+        when(auditLogRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(Page.empty());
+
+        AuditLogPageResponse response = auditLogService.query("EMPLOYEE", null, null, null, null, 0, 20);
+
+        assertThat(response.content()).isEmpty();
+        assertThat(response.totalElements()).isEqualTo(0);
+    }
+
+    @Test
+    void query_ResponseMapsActorNameAndRole() {
+        AuditLog log = AuditLog.builder()
+                .entityType("LEAVE_REQUEST")
+                .entityId(5L)
+                .action(AuditAction.UPDATE)
+                .actor(actor)
+                .actorRole(UserRole.HR_ADMIN)
+                .afterState("{\"status\":\"APPROVED\"}")
+                .build();
+
+        when(auditLogRepository.findAll(any(Specification.class), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(log)));
+
+        AuditLogPageResponse response = auditLogService.query("LEAVE_REQUEST", null, null, null, null, 0, 20);
+
+        assertThat(response.content().getFirst().actorId()).isEqualTo(1L);
+        assertThat(response.content().getFirst().actorName()).isEqualTo("Jordan HR");
+        assertThat(response.content().getFirst().actorRole()).isEqualTo(UserRole.HR_ADMIN);
+        assertThat(response.content().getFirst().action()).isEqualTo(AuditAction.UPDATE);
+    }
+}


### PR DESCRIPTION
## What
Implements the full audit logging system for Epic 9 (US-AUDIT-01, US-AUDIT-02).

Introduces a Spring AOP-based audit system that intercepts annotated write operations
and persists immutable entries to the `audit_logs` table. Exposes a paginated query
endpoint for HR Admins to search the audit trail. Activates logging across all 15
core write operations by annotating the relevant service interfaces.

New files:
- `AuditAction` enum (CREATE / UPDATE / DELETE)
- `AuditLog` entity mapped to the existing `audit_logs` table
- `@Auditable` annotation to mark service methods for interception
- `AuditAspect` — `@Around` advice that captures actor, entity ID, and after-state JSON
- `AuditLogRepository`, `AuditLogService`, `AuditLogServiceImpl`
- `AuditLogSpecification` for dynamic filtering
- `AuditLogController` — `GET /api/v1/audit-logs`
- `AuditLogResponse`, `AuditLogPageResponse` DTOs

Annotated services:
- `EmployeeService` — createEmployee, updateMyProfile, deactivateEmployee
- `LeaveRequestService` — createLeaveRequest, approveLeaveRequest, rejectLeaveRequest, cancelLeaveRequest
- `ShiftService` — createShift, updateShift, cancelShift
- `ShiftAssignmentService` — assignEmployee, removeAssignment
- `ShiftSwapService` — requestSwap, approveSwap, rejectSwap

## Why
FR-AUDIT-01 requires all create, update, and delete operations on core entities to
produce an immutable audit entry recording who changed what and when.
FR-AUDIT-02 requires HR Admins to be able to query that audit trail by entity type,
entity ID, actor, and date range.

## How to test
1. Log in as HR_ADMIN, create an employee via `POST /api/v1/employees`
2. Call `GET /api/v1/audit-logs?entityType=EMPLOYEE` — expect one CREATE entry
   with the correct actorId, actorRole, and afterState JSON
3. Deactivate the employee — re-query and expect a second UPDATE entry
4. Log in as MANAGER, create and cancel a shift
5. Call `GET /api/v1/audit-logs?entityType=SHIFT` — expect CREATE then UPDATE entries
6. Assign an employee to a shift, then remove them
7. Call `GET /api/v1/audit-logs?entityType=SHIFT_ASSIGNMENT` — expect CREATE then DELETE
8. Call `GET /api/v1/audit-logs` without `entityType` — expect 400
9. Log in as EMPLOYEE or MANAGER and call the endpoint — expect 403
10. Verify a failed operation (e.g. duplicate leave request returning 409)
    produces no audit entry

## Notes
- The `AuditAspect` runs after `jp.proceed()` returns without throwing. The
  `@Transactional` proxy commits inside `jp.proceed()`, so if the business operation
  throws the audit save is skipped — satisfying FR-AUDIT-01's rollback requirement.
- `beforeState` is null throughout. Capturing it would require injecting every
  entity's repository into the aspect. `afterState` provides the meaningful snapshot
  for CREATE and UPDATE operations.
- `cancelShift` and `removeAssignment` return void — their entries record the entity
  ID from the method parameter with a null afterState. This is expected behaviour.
- `spring-boot-starter-aop` is not managed by the Spring Boot 4.x BOM, so version
  `4.0.0-M2` is pinned explicitly in `pom.xml`.

### Unrelated fix included in this branch
Fixed a startup failure in `NotificationServiceImpl.onNotificationEvent()`. The method
was annotated with both `@TransactionalEventListener` and `@Transactional` using the
default `REQUIRED` propagation, which Spring 7 forbids. Changed to
`@Transactional(propagation = Propagation.REQUIRES_NEW)` so the notification is
persisted in its own independent transaction after the triggering transaction commits.
This fix was required for the application to start at all.
